### PR TITLE
Use primary text color for nav links to improve contrast

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -374,7 +374,7 @@ nav.is_open .nav-link {
 
 .nav-link {
   font-weight: var(--font-weight-light);
-  color: var(--color-text-secondary);
+  color: var(--color-text-primary);
   text-align: right;
 }
 


### PR DESCRIPTION
The secondary color has a low contrast with the background (Firefox
tells me 4.07, which is less than the recommended minimum of 4.5 ([1])).
Instead of changing the secondary color (which might affect other bits
on the page), just use the primary color for the nav links.

[1]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast