### PR TITLE
Use the current logo for relevant Social sharing meta tags

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,6 +33,16 @@ google_analytics_id: G-C1C9341MGL
 # Build settings
 plugins:
   - jekyll-seo-tag
+
+# Image used by jekyll-seo-tag plugin in the JSON-LD tag.
+logo: "/assets/img/logo.png"
+defaults:
+  - scope:
+      path: ""
+    values:
+      # Image used by jekyll-seo-tag plugin to generate Open Graph and other related meta tags.
+      image: /assets/img/logo.png
+
 # Exclude from processing.
 # The following items will not be processed, by default.
 # Any item listed under the `exclude:` key here will be automatically added to


### PR DESCRIPTION
This will go into the Open Graph meta tags ("og:image", "twitter:image")
as well as the JSON-LD tag.

See jekyll-seo-tag plugin docs:
- [Usage](https://github.com/jekyll/jekyll-seo-tag/blob/master/docs/usage.md)
- [Advanced usage](https://github.com/jekyll/jekyll-seo-tag/blob/master/docs/advanced-usage.md)

This is related to - but does not fix - issue #19. 