### PR TITLE
Fixes #37: Add dark mode styles for county search field.

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -470,9 +470,10 @@ input[type="text"]:focus {
   right: 0;
   padding: 0;
   border-radius: 0 0 5px 5px;
-  background-color: #fff;
+  background-color: var(--color-bg);
   box-shadow: 0 3px 6px rgba(149, 157, 165, 0.15);
   border: 1px solid var(--color-border);
+  color: var(--color-text-primary);
   z-index: var(--z-index-results);
   outline: 0;
 }
@@ -494,4 +495,19 @@ input[type="text"]:focus {
 .autoComplete_selected {
   cursor: pointer;
   background-color: var(--color-accent-bg);
+}
+
+@media (prefers-color-scheme: dark) {
+  input[type="text"] {
+    border: 1px solid var(--color-border--dark);
+  }
+
+  #autoComplete {
+    background-color: var(--color-bg--dark);
+    color: var(--color-text-primary--dark);
+  }
+  #autoComplete_list {
+    background-color: var(--color-bg--dark);
+    color: var(--color-text-primary--dark);
+  }
 }


### PR DESCRIPTION
The commits for the county search field added in pull request #22 contain styles for `background-color: #fff` only. In dark mode (where `color` defaults to white), this results in white text on a white background. (See issue #37 for the original report.)

Update the styles to specify the --color--...--dark variables for `border`, `background-color` and `color` in dark mode. Also use the --color-* variables for `background-color` and `color` in light mode.

Dark mode before:
![image](https://user-images.githubusercontent.com/400880/104893710-9f3bea80-5928-11eb-8373-c4159e87c916.png)

Dark mode after:
![image](https://user-images.githubusercontent.com/400880/104893731-a4009e80-5928-11eb-81fa-e12201d94531.png)

Light mode still works:
![image](https://user-images.githubusercontent.com/400880/104893749-aa8f1600-5928-11eb-9d0a-09f2becc37fc.png)
