### PR TITLE
Ignore .bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ _site
 .jekyll-cache
 .jekyll-metadata
 vendor
+.bundle
 .DS_Store


### PR DESCRIPTION
I --user-install-ed gems here and it's created a .bundle that we should
ignore.