### PR TITLE
Require opt in to nav menu

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,7 +14,7 @@
             <div class="ml-10 flex items-baseline space-x-4">
               {% assign nav = site.pages | sort: 'order' %}
               {% for item in nav  %}
-                {% if item.title %}
+                {% if item.title and item.add_to_nav %}
                   {% if item.url == page.url %}
                     {% assign navItemClasses = "bg-gray-900 text-white" %}
                   {% else %} 
@@ -63,7 +63,7 @@
       <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
         {% assign nav = site.pages | sort: 'order' %}
         {% for item in nav  %}
-          {% if item.title %}
+          {% if item.title and item.add_to_nav %}
             {% if item.url == page.url %}
               {% assign navItemClasses = "bg-gray-900 text-white" %}
             {% else %} 

--- a/county-policies.md
+++ b/county-policies.md
@@ -2,6 +2,7 @@
 layout: default
 title: County Policies
 permalink: /county-policies
+add_to_nav: true
 order: 2
 ---
 The state of California has a vaccine strategy, but has delegated prioritization and administration to each county. Decisions as to which patients to vaccinate and in what fashion are ultimately up to medical providers.

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 
 layout: default
 title: California Covid-19 Vaccine Availability
+add_to_nav: true
 homepage: true
 ---
 

--- a/vaccination-sites.md
+++ b/vaccination-sites.md
@@ -2,6 +2,7 @@
 layout: default
 title: Vaccination Sites
 permalink: /vaccination-sites
+add_to_nav: true
 order: 3
 ---
 This is a list of all of the sites we are aware of in California which will, at some point, receive the covid-19 vaccine. **Most of them do not have the vaccine available today**; we are calling as many as we can daily to update the list.

--- a/who-we-are.md
+++ b/who-we-are.md
@@ -2,6 +2,7 @@
 layout: default
 title: Who We Are
 permalink: /who-we-are
+add_to_nav: true
 order: 4
 ---
 We are an ad hoc collection of volunteers, trying to move as quickly as possible to get Californians up-to-date vaccine information. We have a core team of approximately ten people and approximately 100 volunteers calling to find out about vaccine availability.


### PR DESCRIPTION
Now that we're making a handful of pages that we want as sub-pages, this is a quick fix (can be improved later) to prevent lots of unwanted pages showing up in the top nav.

Just add `add_to_nav: true` in the front matter for a page if it belongs in the nav. Everything else is excluded.