### PR TITLE
Added codeowners from the set of (most) active website contributors

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Global owners
+* @cavaccineinv @eliblock @Manishearth @patio11 @shajith @polybuildr @ranihorev @skalnik @sumeetjain
+


### PR DESCRIPTION
Once this is merged, set merges to only be allowed by owners.