### PR TITLE
Style FAQ title

### DIFF
--- a/who-we-are.md
+++ b/who-we-are.md
@@ -11,9 +11,9 @@ Some of us (so you know we're "real people"): <span id="people-list">
 {% for coordinator in site.data.coordinators %} [{{ coordinator[0] }}]({{ coordinator[1] }}) {% endfor %}
 </span>.
 
-<a name="faq" />
-
-## Frequently Asked Questions (FAQ)
+<h2 class="text-2xl font-bold leading-tight text-gray-900">
+Frequently Asked Questions (FAQ)
+</h2>
 
 **How can I help?**
 


### PR DESCRIPTION
When working on https://github.com/CAVaccineInventory/site/pull/40, I noticed that the FAQ title didn't really have any styling and had an errant link. I rubbed some of the tailwind styling into it and removed that errant `<a>` tag.

Before:
<img width="972" alt="Screen Shot 2021-01-18 at 11 44 01 🌅" src="https://user-images.githubusercontent.com/2546/104957174-7ea07e80-5982-11eb-8379-d814fa7a4be3.png">

After:
<img width="970" alt="Screen Shot 2021-01-18 at 11 43 52 🌅" src="https://user-images.githubusercontent.com/2546/104957187-83653280-5982-11eb-9a15-fdd98329fbbf.png">
