### PR TITLE
Replace anything that looks like a link in location notes

### DIFF
--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -30,14 +30,14 @@ function getDisplayableVaccineInfo(p) {
   }
   function getSchedulingInstructions(p) {
       try {
-          return p["Appointment scheduling instructions"].join(", ")
+          return replaceAnyLinks(p["Appointment scheduling instructions"].join(", "));
       } catch {
           return null
       }
   }
   function getRepNotes(p) {
       try {
-          let notes = p["Latest report notes"].join(" | ");
+          let notes = replaceAnyLinks(p["Latest report notes"].join(" | "));
           if (notes == ' ') {
             return null
           }
@@ -46,6 +46,12 @@ function getDisplayableVaccineInfo(p) {
           return null
       }
   }
+
+  function replaceAnyLinks(body) {
+    let url_regex = /((http|https|ftp):\/\/[\w?=&.\/-;#~%-]+(?![\w\s?&.\/;#~%"=-]*>))/g;
+    return body.replace(url_regex, "<a href='$1' target='_blank'>$1</a>"); 
+  }
+
   let hasReport = getHasReport(p);
   function getYesNo(p) {
     if(hasReport) {
@@ -65,7 +71,7 @@ function getDisplayableVaccineInfo(p) {
     name: p["Name"],
     schedulingInstructions: getSchedulingInstructions(p),
     address: p["Address"] || null,
-    locationNotes: locationNotes,
+    locationNotes: replaceAnyLinks(locationNotes),
     reportNotes: getRepNotes(p),
     longitude: p["Longitude"],
     latitude: p["Latitude"],


### PR DESCRIPTION
![Screen Shot 2021-01-18 at 1 21 43 PM](https://user-images.githubusercontent.com/3237862/104963841-30927780-5990-11eb-9c14-3ffe8cac7e35.png)

Replace any anything that might be a URL in location notes with a clickable link

## Other Notes:
- @Manishearth lemme know if I missed anywhere; wasn't sure where "nearest" was