### PR TITLE
Fix autocomplete list background not showing on devices with dark mode on

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -23,23 +23,6 @@ a {
   width: 100%;
 }
 
-/*input[type="text"] {
-  margin: 0;
-  padding: var(--spacing-s);
-  box-sizing: border-box;
-  text-overflow: ellipsis;
-  outline: 0;
-  border-radius: 3px;
-  border: 1px solid var(--color-border);
-  box-shadow: none;
-  appearance: none;
-  -webkit-appearance: none;
-}
-
-input[type="text"]:focus {
-  border-color: var(--color-text-secondary);
-}*/
-
 #autoComplete {
   width: 100%;
   padding: 4px 8px;
@@ -83,25 +66,6 @@ input[type="text"]:focus {
 .autoComplete_selected {
   cursor: pointer;
   background-color: var(--color-accent-bg);
-}
-
-@media (prefers-color-scheme: dark) {
-  input[type="text"] {
-    border: 1px solid var(--color-border--dark);
-  }
-
-  #autoComplete {
-    background-color: var(--color-bg--dark);
-    color: var(--color-text-primary--dark);
-  }
-  #autoComplete_list {
-    background-color: var(--color-bg--dark);
-    color: var(--color-text-primary--dark);
-  }
-
-  .mapInfo {
-    --color-text-primary: var(--color-text-primary--light);
-  }
 }
 
 .mapInfo h1 {


### PR DESCRIPTION
We can invest in fuller dark mode support another time. For now, these styles seem to just be causing issues.