### PR TITLE
chore: hide test locations

### DIFF
--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -1,6 +1,6 @@
 // Utilities for working with the JSON feed
 function getHasVaccine(p) {
-  return p["Latest report yes?"] == 1;
+  return p["Latest report yes?"] == 1 && p["Location Type"] != "Test Location";
 }
 
 function getHasReport(p) {


### PR DESCRIPTION
We have some records in our database with `Location Type` set to `Test Location`. These should _never_ appear on our map in production.

I originally intended to check `jekyll.environment` or use a jekyll config to determine the behavior of this (letting test locations through in "staging" and local), but this appears to not be available out of the box. A common online suggestion is setting `environment = jekyll.environment` (or similar) in a `<script>` tag in html templates, but instead I elected to simply always remove these pins.