### PR TITLE
ci: shift to team rather than individuals

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # Global owners
-* @cavaccineinv @eliblock @Manishearth @patio11 @shajith @polybuildr @ranihorev @skalnik @sumeetjain
+* @CAVaccineInventory/site-approvers
 


### PR DESCRIPTION
Rather than enumerating individuals in `CODEOWNERS`, shift to a team consisting of all the same individuals.

This will allow us to add auto-assignment to a couple of folks without messaging everyone on every PR (though will also permit all members of @CAVaccineInventory/site-approvers to approve).