### PR TITLE
Update title and text to specify we are focused on "COVID-19" vaccines

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,7 +35,7 @@ plugins:
   - jekyll-seo-tag
 
 ## Social media stuff supported by jekyll-seo-tag
-tagline: Vaccine Availability in California
+tagline: COVID-19 Vaccine Availability in California
 twitter:
   card: summary_large_image
   username: ca_covid

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Vaccine Availability
+title: COVID-19 Vaccine Availability
 add_to_nav: true
 homepage: true
 ---

--- a/who-we-are.md
+++ b/who-we-are.md
@@ -5,7 +5,7 @@ permalink: /who-we-are
 add_to_nav: true
 order: 5
 ---
-We are an ad hoc collection of volunteers, trying to move as quickly as possible to get Californians up-to-date vaccine information. We have a core team of approximately ten people and approximately 100 volunteers calling to find out about vaccine availability.
+We are an ad hoc collection of volunteers, trying to move as quickly as possible to get Californians up-to-date COVID-19 vaccine information. We have a core team of approximately ten people and approximately 100 volunteers calling to find out about vaccine availability.
 
 Some of us (so you know we're "real people"): <span id="people-list">
 {% for coordinator in site.data.coordinators %} [{{ coordinator[0] }}]({{ coordinator[1] }}) {% endfor %}


### PR DESCRIPTION
Proposing to update the title and text to specify that we are focused on COVID-19 vaccines, since COVID-19 is no longer part of our domain name.