### PR TITLE
Add language about government sites

### DIFF
--- a/_includes/disclaimer.html
+++ b/_includes/disclaimer.html
@@ -1,0 +1,5 @@
+<div class="font-medium">
+	<p>California’s statewide COVID-19 vaccination program has been evolving rapidly. <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/index.html">Federal</a>, <a href="https://covid19.ca.gov/vaccines/">state</a>, and <a href="https://www.vaccinateca.com/county-policies">county</a> officials are all publishing frequent updates. These government websites are your best source for official information.</p>
+
+	<p>We are a community-led website and do not represent the government or any healthcare provider.</p>	
+</div>

--- a/index.html
+++ b/index.html
@@ -15,6 +15,10 @@ homepage: true
     calling hospitals and pharmacies daily to check which are currently
     administering vaccines.
 
+    <div class="lg:hidden mt-5 text-sm text-gray-900">
+      {% include disclaimer.html %}
+    </div>
+
     {% include regions_picker.html %}
   </div>
 
@@ -23,7 +27,7 @@ homepage: true
   </div>
 </div>
 
-<div class="my-8">
+<div class="mt-8 mb-5">
   <div class="mt-5">
     <a href="https://airtable.com/shrOMv5EI1jYwV1XR" class="block md:inline px-5 py-3 border-2 border-green-500 text-green-700 font-bold rounded hover:bg-green-500 hover:text-white">Let us know if you found this site useful!</a>
   </div>
@@ -31,6 +35,10 @@ homepage: true
   <div class="mt-4 md:mt-6 text-sm">
     If you have a missing location to report, or think we have incorrect contact information, <a href="https://airtable.com/shrY44NvEjHBscrOH">please let us know.</a>
   </div>
+</div>
+
+<div class="hidden lg:block text-gray-900 mb-8">
+  {% include disclaimer.html %}
 </div>
 
 {% include coverage.html %}


### PR DESCRIPTION
Context: https://discord.com/channels/799147121357881364/799197521540022292/802348630366224436

Above the fold isn't necessarily easy on all devices with our current layout. The new design @ranihorev is working on should make this easier. For now, if the important thing is to get the language on the site here is a proposal.

On mobile:
<img width="432" alt="Screen Shot 2021-01-22 at 6 42 18 PM" src="https://user-images.githubusercontent.com/29388/105566540-9a3cb980-5ce1-11eb-9050-0920e7a90d18.png">

On iPad:
<img width="624" alt="Screen Shot 2021-01-22 at 6 42 51 PM" src="https://user-images.githubusercontent.com/29388/105566550-a7f23f00-5ce1-11eb-8fa1-e97de70518e8.png">

On desktop:
<img width="1547" alt="Screen Shot 2021-01-22 at 6 43 39 PM" src="https://user-images.githubusercontent.com/29388/105566576-c35d4a00-5ce1-11eb-9f18-fa2d90a3bd8a.png">

Preview at https://deploy-preview-160--vaccinateca.netlify.app/