### PR TITLE
Fix jekyll deps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,3 +32,7 @@ gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 # github pages support 2.6.1 and not more recent versions
 # source: https://pages.github.com/versions/
 gem 'jekyll-seo-tag', '2.6.1'
+
+gem "json", "~> 2.5"
+
+gem "bigdecimal", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    bigdecimal (3.0.0)
     colorator (1.1.0)
     concurrent-ruby (1.1.7)
     em-websocket (0.5.2)
@@ -37,6 +38,7 @@ GEM
       jekyll (>= 3.3, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
+    json (2.5.1)
     kramdown (2.3.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -69,9 +71,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bigdecimal (~> 3.0)
   jekyll (~> 4.1.1)
   jekyll-feed (~> 0.12)
   jekyll-seo-tag (= 2.6.1)
+  json (~> 2.5)
   minima (~> 2.5)
   tzinfo (~> 1.2)
   tzinfo-data


### PR DESCRIPTION
Discovered when trying to build a Dockerifle.  Jekyll wouldn't run without json and bigdecimal added.