### PR TITLE
Change Google Maps API key back to the project key

### DIFF
--- a/_includes/map.html
+++ b/_includes/map.html
@@ -1,7 +1,7 @@
 <script type="module" id="js_map_src" src="/assets/js/map.js"></script>
 
 <script
-  src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCEs70ql1-rBnCjZVuPDGx7S4SLZQt6-8s&v=weekly"
+  src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDLgxtP80D9RxICUGicbeZf29_qUii9_sk&v=weekly"
   defer
 ></script>
 


### PR DESCRIPTION
The key was changed in #183 and I'm not sure it was intentional.

Fairly small change so not doing the full checklist but I clicked around and the site seems fine and the map still works.

Deploy preview: https://deploy-preview-191--vaccinateca.netlify.app/