### PR TITLE
Don't use String.replaceAll

### DIFF
--- a/assets/js/airtable-autocomplete.js
+++ b/assets/js/airtable-autocomplete.js
@@ -11,7 +11,7 @@ function updateFilterFromUrlFragment() {
     airtableBaseUrl = airtable.src;
   }
   if (window.location.hash.length > 1) {
-    const countyName = window.location.hash.substring(1).replaceAll("_", " ");
+    const countyName = window.location.hash.substring(1).replace(/_/g, " ");
     const input = document.querySelector("#autoComplete");
     if (counties.indexOf(countyName) == -1) {
       return;
@@ -56,7 +56,7 @@ window.onload = () => {
           airtableBaseUrl = airtable.src;
         }
         airtable.src = airtableBaseUrl + "&filter_County=" + selected;
-        window.location.hash = selected.replaceAll(" ", "_");
+        window.location.hash = selected.replace(/ /g, "_");
       },
     });
 

--- a/assets/js/region.js
+++ b/assets/js/region.js
@@ -9,7 +9,7 @@ window.addEventListener("hashchange", updateFilterFromUrlFragment);
 function updateFilterFromUrlFragment() {
   const counties = getCounties();
   if (window.location.hash.length > 1) {
-    const countyName = window.location.hash.substring(1).replaceAll("_", " ");
+    const countyName = window.location.hash.substring(1).replace(/_/g, " ");
     const input = document.querySelector(".js_autocomplete");
     if (counties.indexOf(countyName) == -1) {
       return;
@@ -123,7 +123,7 @@ function filterCounties(input, county) {
 }
 
 function updateLocationHash(input) {
-  window.location.hash = input.value.replaceAll(" ", "_");
+  window.location.hash = input.value.replace(/ /g, "_");
 }
 
 function getCounties() {


### PR DESCRIPTION
replaceAll is a relatively recent function, and is only supported by browsers from late-2020 or later. We are especially seeing Sentry errors from slightly-stale Mobile Safari versions and Samsung Internet.

(See https://caniuse.com/mdn-javascript_builtins_string_replaceall for a reference on current support)

This should fix a handful of Sentry errors - WEBSITE-E, WEBSITE-Y, WEBSITE-1A, and WEBSITE-1K.

~I attempted to validate that this still behaved correctly in the presence of multiple spaces, but we don't have any counties with two spaces (since we drop the "County" from cities like "San Francisco" and "Los Angeles").~ I've verified thta this works on the policy and vaccination site pages using San Mateo County.

Link to Deploy Preview: https://deploy-preview-198--vaccinateca.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

Open the deploy preview and manually perform the following tests with the browser's developer console open. Fix or log any unexpected errors you see in the console. Check off the following manual tests as you go through them. Make sure to resize the screen and check for poorly positioned or spaced items at mobile and tablet sizes (60%+ of our audience is on mobile devices).

#### Homepage
- [x] Click all the links, internal and external, make sure all open the expected content.
- [x] Verify map pins show information, can locate by geolocation

#### /near-me
- [x] Verify searching by geolocation
- [x] Verify searching by zip code (Use one you're familiar with and double-check the listings are what you'd expect)
- [x] Run seaches using different options of the filters dropdown
- [x] Vaccination Site Cards show relevant information and whether location is within your county
- [x] Address in Vaccination Site Cards links to Google Maps view

#### /regions/* and /vaccination-sites
- [x] List of locations displays successfully on load
- [x] Typing into the 'Search by county...' field activates autocomplete and filters the list of locations
- [x] Region pages should list the region's counties, each linked to its County Page

#### /counties/*
- [x] List of locations displays successfully on load, split into sites with vaccine and without vaccine
- [ ] Vaccination Site Cards show relevant information and whether location is within your county

#### County Policies page
- [x] Shows list of policies per county
- [x] Has search bar that autocompletes and filters content

### Vaccination Sites page
- [x] Lists all vaccination sites
- [x] Has search bar that autocomplete and filters content

#### Other Pages
- [x] 'Providers' shows list of providers
- [x] 'About Us' shows prose content and FAQ
- [x] 'About Us' shows randomized list of coordinators' names

#### Did you remember to:
- [x] Check for errors in the developer console?
- [ ] Resize the window to check for display/positioning issues at mobile and tablet sizes?
- [ ] Check if page titles (what shows in the browser tab) are set properly?
