### PR TITLE
Flip the order of text and counties in small viewports on the main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ homepage: true
 
   <div class="mt-16 bg-yellow-300 py-8 md:py-12 w-screen">
     <div
-      class="flex-col-reversed px-4 space-y-12 md:space-y-0 md:grid md:grid-cols-2 md:gap-x-10 md:px-12"
+      class="flex flex-col-reverse px-4 md:space-y-0 md:grid md:grid-cols-2 md:gap-x-10 md:px-12"
     >
       <div>
         <div class="text-xl font-bold mb-4 md:mb-8">
@@ -44,7 +44,7 @@ homepage: true
           >
         </div>
       </div>
-      <div>
+      <div class="pb-6 md:pb-0">
         <div class="text-xl font-bold mb-4 md:mb-8">
           {% t index.more_info %}
         </div>


### PR DESCRIPTION
Before:
<img width="573" alt="Screen Shot 2021-01-25 at 7 02 53 🌃" src="https://user-images.githubusercontent.com/2546/105794491-fac93200-5f3f-11eb-9077-7f331b5be6ec.png">

After:
<img width="575" alt="Screen Shot 2021-01-25 at 7 03 06 🌃" src="https://user-images.githubusercontent.com/2546/105794502-fef54f80-5f3f-11eb-89a5-73afc736f753.png">

This seems to mirror what we have in @malthesig's mock ups. I think we just had a small mistake in the classes to accomplish this.


Link to Deploy Preview: https://deploy-preview-211--vaccinateca.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

Open the deploy preview and manually perform the following tests with the browser's developer console open. Fix or log any unexpected errors you see in the console. Check off the following manual tests as you go through them. Make sure to resize the screen and check for poorly positioned or spaced items at mobile and tablet sizes (60%+ of our audience is on mobile devices).

#### Homepage
- [x] Click all the links, internal and external, make sure all open the expected content.
- [x] Verify map pins show information, can locate by geolocation
