### PR TITLE
Remove the "In Your County" on County Pages from the Q&A script

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,7 +36,7 @@ Open the deploy preview and manually perform the following tests with the browse
 
 #### /counties/*
 - [ ] List of locations displays successfully on load, split into sites with vaccine and without vaccine
-- [ ] Vaccination Site Cards show relevant information and whether location is within your county
+- [ ] Vaccination Site Cards show relevant information
 
 #### County Policies page
 - [ ] Shows list of policies per county


### PR DESCRIPTION
This never existed, and probably showed up due to some copy and paste. So lets fix that!