### PR TITLE
add report information to each location card

### DIFF
--- a/_includes/site_template.html
+++ b/_includes/site_template.html
@@ -70,9 +70,7 @@
         class="px-4 py-4 flex flex-row items-center border-t border-gray-100 text-sm"
       >
         <div class="mr-2">{% include svg/question_mark.svg %}</div>
-        <div>
-          {% t index.corrections %}
-        </div>
+        <div>{% t index.corrections %}</div>
       </div>
     </div>
     <div class="site_no_report mt-3 px-2 md:px-4">


### PR DESCRIPTION
<!--
	Replace this comment with a description of the change(s) being made.
	Screenshots are especially useful if you want to show how the site is changing.
	If relevant, try to reference Issue IDs that this PR resolves.
-->
Attempt to address #230, but this might be overkill:
![image](https://user-images.githubusercontent.com/7978434/105904028-7a551080-5fd5-11eb-87ec-cd9b3ffeef39.png)

It gets really dense, really quickly. An alternative could be to put this at the top of the page, maybe somewhere in here: 
![image](https://user-images.githubusercontent.com/7978434/105904085-8f31a400-5fd5-11eb-9f0d-cd0f547c68c8.png)

Also looking for copy feedback- just took what was on the homepage but we might want something more targeted in this case.

<!--
	Replace the NNN in the URL below with the ID of this Pull Request.
	That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-233--vaccinateca.netlify.app/

---