### PR TITLE
Remove `replaceAll` since it errors on some browsers

### DIFF
--- a/assets/js/counties-autocomplete.js
+++ b/assets/js/counties-autocomplete.js
@@ -28,7 +28,7 @@ window.addEventListener("load", () => {
       const newUrl = `/counties/${selected
         .replace(" County", "")
         .trim()
-        .replaceAll(" ", "_")}`;
+        .replace(/\ /g, "_")}`;
       window.location.href = newUrl;
     },
   });


### PR DESCRIPTION
As in https://github.com/CAVaccineInventory/site/pull/198, we have another `replaceAll`, which is a bit too modern for some of our users. This PR swaps it with a `replace` and a global regex, which is compatible with some older browsers.

<!--
	Replace the NNN in the URL below with the ID of this Pull Request.
	That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-301--vaccinateca.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

Open the deploy preview and manually perform the following tests with the browser's developer console open. Fix or log any unexpected errors you see in the console. Check off the following manual tests as you go through them. Make sure to resize the screen and check for poorly positioned or spaced items at mobile and tablet sizes (60%+ of our audience is on mobile devices).

#### Homepage
- [x] Search box lets you search by zip or county
- [x] Counties autocomplete and take you to county page

#### /near-me
- [x] Verify searching by geolocation
- [x] Verify searching by zip code (Use one you're familiar with and double-check the listings are what you'd expect)
- [x] Map should move when you geolocate or search via zip
- [x] Run searches using different options of the filters drop down
  - [x] Ensure map populates with sites that match filter
- [x] Vaccination Site Cards show relevant information
- [x] Address in Vaccination Site Cards links to Google Maps view
- [x] Panning map changes sites listed

#### County Vaccination Site List page
- [x] List of locations displays successfully on load, split into sites with vaccine and without vaccine
- [x] Vaccination Site Cards show relevant information

#### County Policies page
- [x] Shows list of policies per county
- [x] Has search bar that autocompletes and filters content

### Vaccination Sites page
- [x] Lists all vaccination sites
- [x] Has search bar that autocomplete and filters content

#### Did you remember to:
- [x] Check for errors in the developer console?
- [x] Resize the window to check for display/positioning issues at mobile and tablet sizes?
- [x] Check if page titles (what shows in the browser tab) are set properly?