### PR TITLE
Switch to fetching from our new fancy CDN URL.

### DIFF
--- a/webpack/data/counties.js
+++ b/webpack/data/counties.js
@@ -1,14 +1,13 @@
 // Calls the JSON feed to pull down counties data
 async function fetchCounties() {
-  const siteURL =
-    "https://storage.googleapis.com/cavaccineinventory-sitedata/airtable-sync/Counties.json";
+  const siteURL = "https://api.vaccinateca.com/v1/counties.json";
   const response = await fetch(siteURL);
 
   if (!response.ok) {
     alert("Could not retrieve the vaccination site data.");
     return;
   }
-  return response.json();
+  return response.json()["content"];
 }
 
 export { fetchCounties };

--- a/webpack/data/locations.js
+++ b/webpack/data/locations.js
@@ -13,15 +13,14 @@ async function fetchSites() {
     });
   }
   isFetching = true;
-  const response = await fetch(
-    "https://storage.googleapis.com/cavaccineinventory-sitedata/airtable-sync/Locations.json?v=1"
-  );
+  const response = await fetch("https://api.vaccinateca.com/v1/locations.json");
 
   if (!response.ok) {
     alert(window.messageCatalog["data_js_alert"]);
     return;
   }
-  _fetchedSites = await response.json();
+  const _fetchedData = await response.json();
+  _fetchedSites = _fetchedData["content"];
   isFetching = false;
   subscribers.forEach((cb) => cb(_fetchedSites));
   return _fetchedSites;


### PR DESCRIPTION
The data contained in api.vaccinateca.com/v1/ is identical to the
previous URLs, except placed inside a "content" key; this provides a
place to put metadata.  Currently, this looks like:

```
{
   "content" : [
      ...
   ],
   "usage" : {
      "contact" : {
         "partnersEmail" : "partners@vaccinateca.com"
      },
      "notice" : "Please contact VaccinateCA and let us know if you plan to rely on or publish this data. This data is provided with best-effort accuracy. If you are displaying this data, we expect you to display it responsibly. Please do not display it in a way that is easy to misread."
   }
}
```

<!--
	Replace the NNN in the URL below with the ID of this Pull Request.
	That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-327--vaccinateca.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

Open the deploy preview and manually perform the following tests with the browser's developer console open. Fix or log any unexpected errors you see in the console. Check off the following manual tests as you go through them. Make sure to resize the screen and check for poorly positioned or spaced items at mobile and tablet sizes (60%+ of our audience is on mobile devices).

#### Homepage
- [x] Click all the links, internal and external, make sure all open the expected content.
- [x] Search box lets you search by zip or county
- [x] Counties autocomplete and take you to county page

#### /near-me
- [x] Verify searching by geolocation
- [x] Verify searching by zip code (Use one you're familiar with and double-check the listings are what you'd expect)
- [x] Map should move when you geolocate or search via zip
- [x] Run searches using different options of the filters drop down
  - [x] Ensure map populates with sites that match filter
- [x] Vaccination Site Cards show relevant information
- [x] Address in Vaccination Site Cards links to Google Maps view
- [x] Panning map changes sites listed

#### County Vaccination Site List page
- [x] List of locations displays successfully on load, split into sites with vaccine and without vaccine
- [x] Vaccination Site Cards show relevant information

#### County Policies page
- [x] Shows list of policies per county
- [x] Has search bar that autocompletes and filters content

### Vaccination Sites page
- [x] Lists all vaccination sites
- [x] Has search bar that autocomplete and filters content

#### Other pages
- [x] 'Providers' shows list of providers
- [x] 'About Us' shows prose content and FAQ
- [x] 'About Us' shows randomized list of coordinators' names

#### Did you remember to:
- [x] Check for errors in the developer console?
- [x] Resize the window to check for display/positioning issues at mobile and tablet sizes?
- [x] Check if page titles (what shows in the browser tab) are set properly?
