### PR TITLE
Embed zip codes and remove opendatasoft fallback

### DIFF
--- a/webpack/data/locations.js
+++ b/webpack/data/locations.js
@@ -26,14 +26,6 @@ async function fetchSites() {
   return _fetchedSites;
 }
 
-async function fetchZipCodesData() {
-  const res = await fetch("assets/json/zipCodes.json");
-  if (res.ok) {
-    return await res.json();
-  }
-  return null;
-}
-
 // Utilities for working with the JSON feed
 function getHasVaccine(p) {
   try {
@@ -223,7 +215,6 @@ export {
   getCoord,
   getCounty,
   getTimeDiffFromNow,
-  fetchZipCodesData,
   splitSitesByVaccineState,
   sortByRecency,
 };

--- a/webpack/json/zipCodes.json
+++ b/webpack/json/zipCodes.json
@@ -1,0 +1,16502 @@
+{
+  "89439": {
+    "coordinates": {
+      "latitude": 39.523693,
+      "longitude": -120.03012
+    }
+  },
+  "90001": {
+    "coordinates": {
+      "latitude": 33.9697897,
+      "longitude": -118.2468148
+    }
+  },
+  "90002": {
+    "coordinates": {
+      "latitude": 33.9511133,
+      "longitude": -118.2497386
+    }
+  },
+  "90003": {
+    "coordinates": {
+      "latitude": 33.9657994,
+      "longitude": -118.2731269
+    }
+  },
+  "90004": {
+    "coordinates": {
+      "latitude": 34.0748887,
+      "longitude": -118.3082034
+    }
+  },
+  "90005": {
+    "coordinates": {
+      "latitude": 34.0578814,
+      "longitude": -118.3096648
+    }
+  },
+  "90006": {
+    "coordinates": {
+      "latitude": 34.0470832,
+      "longitude": -118.2965121
+    }
+  },
+  "90007": {
+    "coordinates": {
+      "latitude": 34.0295114,
+      "longitude": -118.2848199
+    }
+  },
+  "90008": {
+    "coordinates": {
+      "latitude": 34.0083231,
+      "longitude": -118.3491169
+    }
+  },
+  "90009": {
+    "coordinates": {
+      "latitude": 33.9532336,
+      "longitude": -118.3869165
+    }
+  },
+  "90010": {
+    "coordinates": {
+      "latitude": 34.0625448,
+      "longitude": -118.3089341
+    }
+  },
+  "90011": {
+    "coordinates": {
+      "latitude": 34.007889,
+      "longitude": -118.2585096
+    }
+  },
+  "90012": {
+    "coordinates": {
+      "latitude": 34.0653347,
+      "longitude": -118.243891
+    }
+  },
+  "90013": {
+    "coordinates": {
+      "latitude": 34.0445905,
+      "longitude": -118.2405557
+    }
+  },
+  "90014": {
+    "coordinates": {
+      "latitude": 34.0434783,
+      "longitude": -118.2519314
+    }
+  },
+  "90015": {
+    "coordinates": {
+      "latitude": 34.0390107,
+      "longitude": -118.2672801
+    }
+  },
+  "90016": {
+    "coordinates": {
+      "latitude": 34.0255188,
+      "longitude": -118.3520389
+    }
+  },
+  "90017": {
+    "coordinates": {
+      "latitude": 34.0543797,
+      "longitude": -118.2672801
+    }
+  },
+  "90018": {
+    "coordinates": {
+      "latitude": 34.0309972,
+      "longitude": -118.319894
+    }
+  },
+  "90019": {
+    "coordinates": {
+      "latitude": 34.0489277,
+      "longitude": -118.3403506
+    }
+  },
+  "90020": {
+    "coordinates": {
+      "latitude": 34.0655627,
+      "longitude": -118.3096648
+    }
+  },
+  "90021": {
+    "coordinates": {
+      "latitude": 34.0309258,
+      "longitude": -118.2380432
+    }
+  },
+  "90022": {
+    "coordinates": {
+      "latitude": 34.0238187,
+      "longitude": -118.153228
+    }
+  },
+  "90023": {
+    "coordinates": {
+      "latitude": 34.0224471,
+      "longitude": -118.2000277
+    }
+  },
+  "90024": {
+    "coordinates": {
+      "latitude": 34.0631451,
+      "longitude": -118.4367551
+    }
+  },
+  "90025": {
+    "coordinates": {
+      "latitude": 34.0448583,
+      "longitude": -118.4484367
+    }
+  },
+  "90026": {
+    "coordinates": {
+      "latitude": 34.0796167,
+      "longitude": -118.2585096
+    }
+  },
+  "90027": {
+    "coordinates": {
+      "latitude": 34.1220545,
+      "longitude": -118.2935891
+    }
+  },
+  "90028": {
+    "coordinates": {
+      "latitude": 34.1012181,
+      "longitude": -118.325739
+    }
+  },
+  "90029": {
+    "coordinates": {
+      "latitude": 34.0880507,
+      "longitude": -118.2965121
+    }
+  },
+  "90030": {
+    "coordinates": {
+      "latitude": 34.06,
+      "longitude": -118.24
+    }
+  },
+  "90031": {
+    "coordinates": {
+      "latitude": 34.081032,
+      "longitude": -118.2117257
+    }
+  },
+  "90032": {
+    "coordinates": {
+      "latitude": 34.0795169,
+      "longitude": -118.1766294
+    }
+  },
+  "90033": {
+    "coordinates": {
+      "latitude": 34.0502898,
+      "longitude": -118.2117257
+    }
+  },
+  "90034": {
+    "coordinates": {
+      "latitude": 34.0324632,
+      "longitude": -118.395863
+    }
+  },
+  "90035": {
+    "coordinates": {
+      "latitude": 34.050751,
+      "longitude": -118.3841777
+    }
+  },
+  "90036": {
+    "coordinates": {
+      "latitude": 34.0664817,
+      "longitude": -118.3520389
+    }
+  },
+  "90037": {
+    "coordinates": {
+      "latitude": 34.002058,
+      "longitude": -118.2818967
+    }
+  },
+  "90038": {
+    "coordinates": {
+      "latitude": 34.0895186,
+      "longitude": -118.3315838
+    }
+  },
+  "90039": {
+    "coordinates": {
+      "latitude": 34.1103407,
+      "longitude": -118.2585096
+    }
+  },
+  "90040": {
+    "coordinates": {
+      "latitude": 33.9930471,
+      "longitude": -118.153228
+    }
+  },
+  "90041": {
+    "coordinates": {
+      "latitude": 34.13224690000001,
+      "longitude": -118.2117257
+    }
+  },
+  "90042": {
+    "coordinates": {
+      "latitude": 34.1175895,
+      "longitude": -118.188329
+    }
+  },
+  "90043": {
+    "coordinates": {
+      "latitude": 33.9903827,
+      "longitude": -118.3286614
+    }
+  },
+  "90044": {
+    "coordinates": {
+      "latitude": 33.9478802,
+      "longitude": -118.2935891
+    }
+  },
+  "90045": {
+    "coordinates": {
+      "latitude": 33.9516114,
+      "longitude": -118.3875775
+    }
+  },
+  "90046": {
+    "coordinates": {
+      "latitude": 34.1147313,
+      "longitude": -118.3637264
+    }
+  },
+  "90047": {
+    "coordinates": {
+      "latitude": 33.9519253,
+      "longitude": -118.3082034
+    }
+  },
+  "90048": {
+    "coordinates": {
+      "latitude": 34.0741548,
+      "longitude": -118.3724915
+    }
+  },
+  "90049": {
+    "coordinates": {
+      "latitude": 34.0963058,
+      "longitude": -118.4980744
+    }
+  },
+  "90050": {
+    "coordinates": {
+      "latitude": 34.1206108,
+      "longitude": -118.2036321
+    }
+  },
+  "90051": {
+    "coordinates": {
+      "latitude": 33.95,
+      "longitude": -118.25
+    }
+  },
+  "90052": {
+    "coordinates": {
+      "latitude": 33.9788726,
+      "longitude": -118.2592405
+    }
+  },
+  "90053": {
+    "coordinates": {
+      "latitude": 34.0499892,
+      "longitude": -118.2399854
+    }
+  },
+  "90054": {
+    "coordinates": {
+      "latitude": 34.06,
+      "longitude": -118.24
+    }
+  },
+  "90055": {
+    "coordinates": {
+      "latitude": 34.038371,
+      "longitude": -118.2584017
+    }
+  },
+  "90056": {
+    "coordinates": {
+      "latitude": 33.9885683,
+      "longitude": -118.3666482
+    }
+  },
+  "90057": {
+    "coordinates": {
+      "latitude": 34.06170609999999,
+      "longitude": -118.2789735
+    }
+  },
+  "90058": {
+    "coordinates": {
+      "latitude": 34.00637469999999,
+      "longitude": -118.2234229
+    }
+  },
+  "90059": {
+    "coordinates": {
+      "latitude": 33.9287591,
+      "longitude": -118.2468148
+    }
+  },
+  "90060": {
+    "coordinates": {
+      "latitude": 34.06,
+      "longitude": -118.24
+    }
+  },
+  "90061": {
+    "coordinates": {
+      "latitude": 33.9196443,
+      "longitude": -118.2731269
+    }
+  },
+  "90062": {
+    "coordinates": {
+      "latitude": 34.0031792,
+      "longitude": -118.3082034
+    }
+  },
+  "90063": {
+    "coordinates": {
+      "latitude": 34.0440239,
+      "longitude": -118.1854042
+    }
+  },
+  "90064": {
+    "coordinates": {
+      "latitude": 34.0386656,
+      "longitude": -118.4221519
+    }
+  },
+  "90065": {
+    "coordinates": {
+      "latitude": 34.10885,
+      "longitude": -118.2234229
+    }
+  },
+  "90066": {
+    "coordinates": {
+      "latitude": 34.0050173,
+      "longitude": -118.4338345
+    }
+  },
+  "90067": {
+    "coordinates": {
+      "latitude": 34.0571327,
+      "longitude": -118.4148498
+    }
+  },
+  "90068": {
+    "coordinates": {
+      "latitude": 34.1235157,
+      "longitude": -118.3286614
+    }
+  },
+  "90069": {
+    "coordinates": {
+      "latitude": 34.0931603,
+      "longitude": -118.3783347
+    }
+  },
+  "90070": {
+    "coordinates": {
+      "latitude": 34.0598902,
+      "longitude": -118.3101649
+    }
+  },
+  "90071": {
+    "coordinates": {
+      "latitude": 34.052996,
+      "longitude": -118.2548551
+    }
+  },
+  "90072": {
+    "coordinates": {
+      "latitude": 34.0965275,
+      "longitude": -118.3092914
+    }
+  },
+  "90073": {
+    "coordinates": {
+      "latitude": 34.0522561,
+      "longitude": -118.452087
+    }
+  },
+  "90074": {
+    "coordinates": {
+      "latitude": 34.0499441,
+      "longitude": -118.2598191
+    }
+  },
+  "90075": {
+    "coordinates": {
+      "latitude": 34.059975,
+      "longitude": -118.3100196
+    }
+  },
+  "90076": {
+    "coordinates": {
+      "latitude": 34.05998090000001,
+      "longitude": -118.3099973
+    }
+  },
+  "90077": {
+    "coordinates": {
+      "latitude": 34.1014861,
+      "longitude": -118.4571974
+    }
+  },
+  "90078": {
+    "coordinates": {
+      "latitude": 34.0993907,
+      "longitude": -118.3310632
+    }
+  },
+  "90079": {
+    "coordinates": {
+      "latitude": 34.0405313,
+      "longitude": -118.2554032
+    }
+  },
+  "90080": {
+    "coordinates": {
+      "latitude": 33.95,
+      "longitude": -118.38
+    }
+  },
+  "90081": {
+    "coordinates": {
+      "latitude": 34.052984,
+      "longitude": -118.2511908
+    }
+  },
+  "90082": {
+    "coordinates": {
+      "latitude": 33.9999897,
+      "longitude": -118.2798042
+    }
+  },
+  "90083": {
+    "coordinates": {
+      "latitude": 33.95,
+      "longitude": -118.4
+    }
+  },
+  "90084": {
+    "coordinates": {
+      "latitude": 34.05,
+      "longitude": -118.26
+    }
+  },
+  "90086": {
+    "coordinates": {
+      "latitude": 34.06,
+      "longitude": -118.24
+    }
+  },
+  "90087": {
+    "coordinates": {
+      "latitude": 34.06,
+      "longitude": -118.24
+    }
+  },
+  "90088": {
+    "coordinates": {
+      "latitude": 34.05,
+      "longitude": -118.26
+    }
+  },
+  "90089": {
+    "coordinates": {
+      "latitude": 34.0220127,
+      "longitude": -118.2892046
+    }
+  },
+  "90091": {
+    "coordinates": {
+      "latitude": 33.9899979,
+      "longitude": -118.1499982
+    }
+  },
+  "90093": {
+    "coordinates": {
+      "latitude": 34.1,
+      "longitude": -118.33
+    }
+  },
+  "90094": {
+    "coordinates": {
+      "latitude": 33.97448060000001,
+      "longitude": -118.4177707
+    }
+  },
+  "90095": {
+    "coordinates": {
+      "latitude": 34.070264,
+      "longitude": -118.4440562
+    }
+  },
+  "90096": {
+    "coordinates": {
+      "latitude": 33.97,
+      "longitude": -118.17
+    }
+  },
+  "90097": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "90099": {
+    "coordinates": {
+      "latitude": 34.06,
+      "longitude": -118.24
+    }
+  },
+  "90101": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "90102": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "90103": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "90174": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "90185": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "90201": {
+    "coordinates": {
+      "latitude": 33.96672119999999,
+      "longitude": -118.1766294
+    }
+  },
+  "90202": {
+    "coordinates": {
+      "latitude": 33.9799999,
+      "longitude": -118.19
+    }
+  },
+  "90204": {
+    "coordinates": {
+      "latitude": 33.944714,
+      "longitude": -118.356908
+    }
+  },
+  "90209": {
+    "coordinates": {
+      "latitude": 34.0699904,
+      "longitude": -118.389995
+    }
+  },
+  "90210": {
+    "coordinates": {
+      "latitude": 34.07018,
+      "longitude": -118.399956
+    }
+  },
+  "90211": {
+    "coordinates": {
+      "latitude": 34.0661071,
+      "longitude": -118.3841777
+    }
+  },
+  "90212": {
+    "coordinates": {
+      "latitude": 34.0617109,
+      "longitude": -118.4017053
+    }
+  },
+  "90213": {
+    "coordinates": {
+      "latitude": 34.0695104,
+      "longitude": -118.3997374
+    }
+  },
+  "90220": {
+    "coordinates": {
+      "latitude": 33.8803536,
+      "longitude": -118.2351192
+    }
+  },
+  "90221": {
+    "coordinates": {
+      "latitude": 33.8890686,
+      "longitude": -118.2000277
+    }
+  },
+  "90222": {
+    "coordinates": {
+      "latitude": 33.9111458,
+      "longitude": -118.2351192
+    }
+  },
+  "90223": {
+    "coordinates": {
+      "latitude": 33.89989,
+      "longitude": -118.2199049
+    }
+  },
+  "90224": {
+    "coordinates": {
+      "latitude": 33.89,
+      "longitude": -118.22
+    }
+  },
+  "90230": {
+    "coordinates": {
+      "latitude": 33.9933257,
+      "longitude": -118.3987842
+    }
+  },
+  "90231": {
+    "coordinates": {
+      "latitude": 34,
+      "longitude": -118.39
+    }
+  },
+  "90232": {
+    "coordinates": {
+      "latitude": 34.0236878,
+      "longitude": -118.3900204
+    }
+  },
+  "90233": {
+    "coordinates": {
+      "latitude": 33.9799584,
+      "longitude": -118.3899667
+    }
+  },
+  "90239": {
+    "coordinates": {
+      "latitude": 33.94,
+      "longitude": -118.13
+    }
+  },
+  "90240": {
+    "coordinates": {
+      "latitude": 33.9574105,
+      "longitude": -118.1210458
+    }
+  },
+  "90241": {
+    "coordinates": {
+      "latitude": 33.9372725,
+      "longitude": -118.1298234
+    }
+  },
+  "90242": {
+    "coordinates": {
+      "latitude": 33.9167378,
+      "longitude": -118.1298234
+    }
+  },
+  "90245": {
+    "coordinates": {
+      "latitude": 33.9150066,
+      "longitude": -118.4046264
+    }
+  },
+  "90247": {
+    "coordinates": {
+      "latitude": 33.8863314,
+      "longitude": -118.2935891
+    }
+  },
+  "90248": {
+    "coordinates": {
+      "latitude": 33.8658064,
+      "longitude": -118.2935891
+    }
+  },
+  "90249": {
+    "coordinates": {
+      "latitude": 33.901022,
+      "longitude": -118.3169714
+    }
+  },
+  "90250": {
+    "coordinates": {
+      "latitude": 33.9127807,
+      "longitude": -118.3520389
+    }
+  },
+  "90251": {
+    "coordinates": {
+      "latitude": 33.92,
+      "longitude": -118.35
+    }
+  },
+  "90254": {
+    "coordinates": {
+      "latitude": 33.8600693,
+      "longitude": -118.3987842
+    }
+  },
+  "90255": {
+    "coordinates": {
+      "latitude": 33.9756107,
+      "longitude": -118.2234229
+    }
+  },
+  "90260": {
+    "coordinates": {
+      "latitude": 33.8922687,
+      "longitude": -118.3520389
+    }
+  },
+  "90261": {
+    "coordinates": {
+      "latitude": 33.8954945,
+      "longitude": -118.3776043
+    }
+  },
+  "90262": {
+    "coordinates": {
+      "latitude": 33.9198647,
+      "longitude": -118.2000277
+    }
+  },
+  "90263": {
+    "coordinates": {
+      "latitude": 34.0327657,
+      "longitude": -118.7037647
+    }
+  },
+  "90264": {
+    "coordinates": {
+      "latitude": 34.0349051,
+      "longitude": -118.6941818
+    }
+  },
+  "90265": {
+    "coordinates": {
+      "latitude": 34.0615492,
+      "longitude": -118.8363756
+    }
+  },
+  "90266": {
+    "coordinates": {
+      "latitude": 33.8908371,
+      "longitude": -118.3987842
+    }
+  },
+  "90267": {
+    "coordinates": {
+      "latitude": 33.88,
+      "longitude": -118.41
+    }
+  },
+  "90270": {
+    "coordinates": {
+      "latitude": 33.9876248,
+      "longitude": -118.1854042
+    }
+  },
+  "90272": {
+    "coordinates": {
+      "latitude": 34.0845245,
+      "longitude": -118.5447787
+    }
+  },
+  "90274": {
+    "coordinates": {
+      "latitude": 33.7793751,
+      "longitude": -118.3520389
+    }
+  },
+  "90275": {
+    "coordinates": {
+      "latitude": 33.7456493,
+      "longitude": -118.3637264
+    }
+  },
+  "90276": {
+    "coordinates": {
+      "latitude": 33.845064,
+      "longitude": -118.395107
+    }
+  },
+  "90277": {
+    "coordinates": {
+      "latitude": 33.8322129,
+      "longitude": -118.3870991
+    }
+  },
+  "90278": {
+    "coordinates": {
+      "latitude": 33.865913,
+      "longitude": -118.3754131
+    }
+  },
+  "90280": {
+    "coordinates": {
+      "latitude": 33.9432948,
+      "longitude": -118.188329
+    }
+  },
+  "90290": {
+    "coordinates": {
+      "latitude": 34.1076983,
+      "longitude": -118.61481
+    }
+  },
+  "90291": {
+    "coordinates": {
+      "latitude": 33.9962144,
+      "longitude": -118.4688776
+    }
+  },
+  "90292": {
+    "coordinates": {
+      "latitude": 33.9684276,
+      "longitude": -118.4571974
+    }
+  },
+  "90293": {
+    "coordinates": {
+      "latitude": 33.9508728,
+      "longitude": -118.4455164
+    }
+  },
+  "90294": {
+    "coordinates": {
+      "latitude": 33.99,
+      "longitude": -118.46
+    }
+  },
+  "90295": {
+    "coordinates": {
+      "latitude": 33.979998,
+      "longitude": -118.4499975
+    }
+  },
+  "90296": {
+    "coordinates": {
+      "latitude": 33.95,
+      "longitude": -118.44
+    }
+  },
+  "90301": {
+    "coordinates": {
+      "latitude": 33.9537917,
+      "longitude": -118.3520389
+    }
+  },
+  "90302": {
+    "coordinates": {
+      "latitude": 33.9742906,
+      "longitude": -118.3520389
+    }
+  },
+  "90303": {
+    "coordinates": {
+      "latitude": 33.93583520000001,
+      "longitude": -118.3315838
+    }
+  },
+  "90304": {
+    "coordinates": {
+      "latitude": 33.9387862,
+      "longitude": -118.3608046
+    }
+  },
+  "90305": {
+    "coordinates": {
+      "latitude": 33.9596334,
+      "longitude": -118.3286614
+    }
+  },
+  "90306": {
+    "coordinates": {
+      "latitude": 33.9599711,
+      "longitude": -118.3499862
+    }
+  },
+  "90307": {
+    "coordinates": {
+      "latitude": 33.96,
+      "longitude": -118.35
+    }
+  },
+  "90308": {
+    "coordinates": {
+      "latitude": 33.96,
+      "longitude": -118.35
+    }
+  },
+  "90309": {
+    "coordinates": {
+      "latitude": 33.97,
+      "longitude": -118.36
+    }
+  },
+  "90310": {
+    "coordinates": {
+      "latitude": 33.93,
+      "longitude": -118.32
+    }
+  },
+  "90311": {
+    "coordinates": {
+      "latitude": 33.96,
+      "longitude": -118.35
+    }
+  },
+  "90312": {
+    "coordinates": {
+      "latitude": 33.9600199,
+      "longitude": -118.349893
+    }
+  },
+  "90313": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "90397": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "90398": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "90401": {
+    "coordinates": {
+      "latitude": 34.0126379,
+      "longitude": -118.495155
+    }
+  },
+  "90402": {
+    "coordinates": {
+      "latitude": 34.0352816,
+      "longitude": -118.5068325
+    }
+  },
+  "90403": {
+    "coordinates": {
+      "latitude": 34.0279895,
+      "longitude": -118.495155
+    }
+  },
+  "90404": {
+    "coordinates": {
+      "latitude": 34.02875,
+      "longitude": -118.4717975
+    }
+  },
+  "90405": {
+    "coordinates": {
+      "latitude": 34.00974600000001,
+      "longitude": -118.4659576
+    }
+  },
+  "90406": {
+    "coordinates": {
+      "latitude": 34.0199977,
+      "longitude": -118.5000014
+    }
+  },
+  "90407": {
+    "coordinates": {
+      "latitude": 34.02,
+      "longitude": -118.5
+    }
+  },
+  "90408": {
+    "coordinates": {
+      "latitude": 34.0258537,
+      "longitude": -118.4903818
+    }
+  },
+  "90409": {
+    "coordinates": {
+      "latitude": 34,
+      "longitude": -118.48
+    }
+  },
+  "90410": {
+    "coordinates": {
+      "latitude": 34.02,
+      "longitude": -118.5
+    }
+  },
+  "90411": {
+    "coordinates": {
+      "latitude": 34.02,
+      "longitude": -118.5
+    }
+  },
+  "90421": {
+    "coordinates": {
+      "latitude": 34.010328,
+      "longitude": -118.494107
+    }
+  },
+  "90501": {
+    "coordinates": {
+      "latitude": 33.8291867,
+      "longitude": -118.3169714
+    }
+  },
+  "90502": {
+    "coordinates": {
+      "latitude": 33.8331717,
+      "longitude": -118.2906661
+    }
+  },
+  "90503": {
+    "coordinates": {
+      "latitude": 33.8409696,
+      "longitude": -118.3520389
+    }
+  },
+  "90504": {
+    "coordinates": {
+      "latitude": 33.8673266,
+      "longitude": -118.3286614
+    }
+  },
+  "90505": {
+    "coordinates": {
+      "latitude": 33.8101772,
+      "longitude": -118.3520389
+    }
+  },
+  "90506": {
+    "coordinates": {
+      "latitude": 33.8844585,
+      "longitude": -118.329392
+    }
+  },
+  "90507": {
+    "coordinates": {
+      "latitude": 33.83,
+      "longitude": -118.31
+    }
+  },
+  "90508": {
+    "coordinates": {
+      "latitude": 33.83,
+      "longitude": -118.31
+    }
+  },
+  "90509": {
+    "coordinates": {
+      "latitude": 33.83,
+      "longitude": -118.33
+    }
+  },
+  "90510": {
+    "coordinates": {
+      "latitude": 33.827044,
+      "longitude": -118.328528
+    }
+  },
+  "90601": {
+    "coordinates": {
+      "latitude": 34.0080684,
+      "longitude": -118.0303189
+    }
+  },
+  "90602": {
+    "coordinates": {
+      "latitude": 33.9717336,
+      "longitude": -118.0215363
+    }
+  },
+  "90603": {
+    "coordinates": {
+      "latitude": 33.9443011,
+      "longitude": -117.9931472
+    }
+  },
+  "90604": {
+    "coordinates": {
+      "latitude": 33.9324943,
+      "longitude": -118.0244639
+    }
+  },
+  "90605": {
+    "coordinates": {
+      "latitude": 33.9548846,
+      "longitude": -118.0273914
+    }
+  },
+  "90606": {
+    "coordinates": {
+      "latitude": 33.9722831,
+      "longitude": -118.0712981
+    }
+  },
+  "90607": {
+    "coordinates": {
+      "latitude": 33.96,
+      "longitude": -118.02
+    }
+  },
+  "90608": {
+    "coordinates": {
+      "latitude": 33.9807825,
+      "longitude": -118.035064
+    }
+  },
+  "90609": {
+    "coordinates": {
+      "latitude": 33.9799999,
+      "longitude": -118.03
+    }
+  },
+  "90610": {
+    "coordinates": {
+      "latitude": 33.97,
+      "longitude": -118.07
+    }
+  },
+  "90612": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "90620": {
+    "coordinates": {
+      "latitude": 33.8428724,
+      "longitude": -118.0127534
+    }
+  },
+  "90621": {
+    "coordinates": {
+      "latitude": 33.8794822,
+      "longitude": -117.9893301
+    }
+  },
+  "90622": {
+    "coordinates": {
+      "latitude": 33.8466648,
+      "longitude": -118.0053395
+    }
+  },
+  "90623": {
+    "coordinates": {
+      "latitude": 33.8477954,
+      "longitude": -118.0449554
+    }
+  },
+  "90624": {
+    "coordinates": {
+      "latitude": 33.85,
+      "longitude": -118
+    }
+  },
+  "90630": {
+    "coordinates": {
+      "latitude": 33.816539,
+      "longitude": -118.0361736
+    }
+  },
+  "90631": {
+    "coordinates": {
+      "latitude": 33.9226618,
+      "longitude": -117.9600466
+    }
+  },
+  "90632": {
+    "coordinates": {
+      "latitude": 33.9173739,
+      "longitude": -117.9592152
+    }
+  },
+  "90633": {
+    "coordinates": {
+      "latitude": 33.9173004,
+      "longitude": -117.9591341
+    }
+  },
+  "90637": {
+    "coordinates": {
+      "latitude": 33.8957,
+      "longitude": -118.0037566
+    }
+  },
+  "90638": {
+    "coordinates": {
+      "latitude": 33.9045543,
+      "longitude": -118.0127534
+    }
+  },
+  "90639": {
+    "coordinates": {
+      "latitude": 33.90528219999999,
+      "longitude": -118.0179682
+    }
+  },
+  "90640": {
+    "coordinates": {
+      "latitude": 34.0149091,
+      "longitude": -118.1064156
+    }
+  },
+  "90650": {
+    "coordinates": {
+      "latitude": 33.90777509999999,
+      "longitude": -118.0830047
+    }
+  },
+  "90651": {
+    "coordinates": {
+      "latitude": 33.9045574,
+      "longitude": -118.0784449
+    }
+  },
+  "90652": {
+    "coordinates": {
+      "latitude": 33.9045574,
+      "longitude": -118.0784449
+    }
+  },
+  "90659": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "90660": {
+    "coordinates": {
+      "latitude": 33.9870228,
+      "longitude": -118.0947106
+    }
+  },
+  "90661": {
+    "coordinates": {
+      "latitude": 33.98594050000001,
+      "longitude": -118.0857083
+    }
+  },
+  "90662": {
+    "coordinates": {
+      "latitude": 33.98594050000001,
+      "longitude": -118.0857083
+    }
+  },
+  "90665": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "90670": {
+    "coordinates": {
+      "latitude": 33.9414796,
+      "longitude": -118.0712981
+    }
+  },
+  "90671": {
+    "coordinates": {
+      "latitude": 33.95,
+      "longitude": -118.08
+    }
+  },
+  "90680": {
+    "coordinates": {
+      "latitude": 33.80248220000001,
+      "longitude": -117.9930967
+    }
+  },
+  "90701": {
+    "coordinates": {
+      "latitude": 33.8648303,
+      "longitude": -118.0800782
+    }
+  },
+  "90702": {
+    "coordinates": {
+      "latitude": 33.8657838,
+      "longitude": -118.0838799
+    }
+  },
+  "90703": {
+    "coordinates": {
+      "latitude": 33.8724552,
+      "longitude": -118.0595907
+    }
+  },
+  "90704": {
+    "coordinates": {
+      "latitude": 33.36146310000001,
+      "longitude": -118.4396756
+    }
+  },
+  "90706": {
+    "coordinates": {
+      "latitude": 33.8822393,
+      "longitude": -118.1239717
+    }
+  },
+  "90707": {
+    "coordinates": {
+      "latitude": 33.8821364,
+      "longitude": -118.1243793
+    }
+  },
+  "90710": {
+    "coordinates": {
+      "latitude": 33.7957752,
+      "longitude": -118.2965121
+    }
+  },
+  "90711": {
+    "coordinates": {
+      "latitude": 33.8522282,
+      "longitude": -118.1330353
+    }
+  },
+  "90712": {
+    "coordinates": {
+      "latitude": 33.8493162,
+      "longitude": -118.153228
+    }
+  },
+  "90713": {
+    "coordinates": {
+      "latitude": 33.8477257,
+      "longitude": -118.1181199
+    }
+  },
+  "90714": {
+    "coordinates": {
+      "latitude": 33.8522282,
+      "longitude": -118.1330353
+    }
+  },
+  "90715": {
+    "coordinates": {
+      "latitude": 33.8413324,
+      "longitude": -118.0783974
+    }
+  },
+  "90716": {
+    "coordinates": {
+      "latitude": 33.83029800000001,
+      "longitude": -118.0742249
+    }
+  },
+  "90717": {
+    "coordinates": {
+      "latitude": 33.7950887,
+      "longitude": -118.319894
+    }
+  },
+  "90720": {
+    "coordinates": {
+      "latitude": 33.7976003,
+      "longitude": -118.0712981
+    }
+  },
+  "90721": {
+    "coordinates": {
+      "latitude": 33.8081254,
+      "longitude": -118.0691286
+    }
+  },
+  "90723": {
+    "coordinates": {
+      "latitude": 33.89777370000001,
+      "longitude": -118.1649291
+    }
+  },
+  "90731": {
+    "coordinates": {
+      "latitude": 33.7241323,
+      "longitude": -118.2643567
+    }
+  },
+  "90732": {
+    "coordinates": {
+      "latitude": 33.7349075,
+      "longitude": -118.3140488
+    }
+  },
+  "90733": {
+    "coordinates": {
+      "latitude": 33.7367479,
+      "longitude": -118.2805078
+    }
+  },
+  "90734": {
+    "coordinates": {
+      "latitude": 33.7358333,
+      "longitude": -118.2922222
+    }
+  },
+  "90740": {
+    "coordinates": {
+      "latitude": 33.7535679,
+      "longitude": -118.0830047
+    }
+  },
+  "90742": {
+    "coordinates": {
+      "latitude": 33.7178819,
+      "longitude": -118.0704585
+    }
+  },
+  "90743": {
+    "coordinates": {
+      "latitude": 33.7284052,
+      "longitude": -118.084295
+    }
+  },
+  "90744": {
+    "coordinates": {
+      "latitude": 33.7857948,
+      "longitude": -118.2643567
+    }
+  },
+  "90745": {
+    "coordinates": {
+      "latitude": 33.8232001,
+      "longitude": -118.2585096
+    }
+  },
+  "90746": {
+    "coordinates": {
+      "latitude": 33.8540061,
+      "longitude": -118.2585096
+    }
+  },
+  "90747": {
+    "coordinates": {
+      "latitude": 33.8641714,
+      "longitude": -118.2558801
+    }
+  },
+  "90748": {
+    "coordinates": {
+      "latitude": 33.7830899,
+      "longitude": -118.2626058
+    }
+  },
+  "90749": {
+    "coordinates": {
+      "latitude": 33.83,
+      "longitude": -118.26
+    }
+  },
+  "90755": {
+    "coordinates": {
+      "latitude": 33.8020217,
+      "longitude": -118.1678543
+    }
+  },
+  "90774": {
+    "coordinates": {
+      "latitude": 33.783038,
+      "longitude": -118.238683
+    }
+  },
+  "90801": {
+    "coordinates": {
+      "latitude": 33.7705139,
+      "longitude": -118.187732
+    }
+  },
+  "90802": {
+    "coordinates": {
+      "latitude": 33.7415317,
+      "longitude": -118.1941785
+    }
+  },
+  "90803": {
+    "coordinates": {
+      "latitude": 33.7523035,
+      "longitude": -118.1298234
+    }
+  },
+  "90804": {
+    "coordinates": {
+      "latitude": 33.7806646,
+      "longitude": -118.1503026
+    }
+  },
+  "90805": {
+    "coordinates": {
+      "latitude": 33.8640647,
+      "longitude": -118.1766294
+    }
+  },
+  "90806": {
+    "coordinates": {
+      "latitude": 33.8065036,
+      "longitude": -118.1912538
+    }
+  },
+  "90807": {
+    "coordinates": {
+      "latitude": 33.8332465,
+      "longitude": -118.1766294
+    }
+  },
+  "90808": {
+    "coordinates": {
+      "latitude": 33.8197825,
+      "longitude": -118.1064156
+    }
+  },
+  "90809": {
+    "coordinates": {
+      "latitude": 33.798194,
+      "longitude": -118.1495712
+    }
+  },
+  "90810": {
+    "coordinates": {
+      "latitude": 33.8113701,
+      "longitude": -118.2234229
+    }
+  },
+  "90813": {
+    "coordinates": {
+      "latitude": 33.7844997,
+      "longitude": -118.1971031
+    }
+  },
+  "90814": {
+    "coordinates": {
+      "latitude": 33.7709051,
+      "longitude": -118.1429889
+    }
+  },
+  "90815": {
+    "coordinates": {
+      "latitude": 33.7963296,
+      "longitude": -118.1181199
+    }
+  },
+  "90822": {
+    "coordinates": {
+      "latitude": 33.8084732,
+      "longitude": -118.1495712
+    }
+  },
+  "90831": {
+    "coordinates": {
+      "latitude": 33.7684556,
+      "longitude": -118.2022212
+    }
+  },
+  "90832": {
+    "coordinates": {
+      "latitude": 33.7699125,
+      "longitude": -118.1999698
+    }
+  },
+  "90833": {
+    "coordinates": {
+      "latitude": 33.7679552,
+      "longitude": -118.1994298
+    }
+  },
+  "90834": {
+    "coordinates": {
+      "latitude": 33.7674587,
+      "longitude": -118.1991138
+    }
+  },
+  "90835": {
+    "coordinates": {
+      "latitude": 33.767963,
+      "longitude": -118.1994298
+    }
+  },
+  "90840": {
+    "coordinates": {
+      "latitude": 33.7838081,
+      "longitude": -118.1206801
+    }
+  },
+  "90842": {
+    "coordinates": {
+      "latitude": 33.83,
+      "longitude": -118.18
+    }
+  },
+  "90844": {
+    "coordinates": {
+      "latitude": 33.7744222,
+      "longitude": -118.1920763
+    }
+  },
+  "90845": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "90846": {
+    "coordinates": {
+      "latitude": 33.8301142,
+      "longitude": -118.145183
+    }
+  },
+  "90847": {
+    "coordinates": {
+      "latitude": 33.83,
+      "longitude": -118.18
+    }
+  },
+  "90848": {
+    "coordinates": {
+      "latitude": 33.83,
+      "longitude": -118.18
+    }
+  },
+  "90853": {
+    "coordinates": {
+      "latitude": 33.7591962,
+      "longitude": -118.1291576
+    }
+  },
+  "90879": {
+    "coordinates": {
+      "latitude": 33.769667,
+      "longitude": -118.313405
+    }
+  },
+  "90888": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "91001": {
+    "coordinates": {
+      "latitude": 34.2103962,
+      "longitude": -118.1239717
+    }
+  },
+  "91003": {
+    "coordinates": {
+      "latitude": 34.19,
+      "longitude": -118.13
+    }
+  },
+  "91006": {
+    "coordinates": {
+      "latitude": 34.1172361,
+      "longitude": -118.0244639
+    }
+  },
+  "91007": {
+    "coordinates": {
+      "latitude": 34.1216975,
+      "longitude": -118.0478826
+    }
+  },
+  "91009": {
+    "coordinates": {
+      "latitude": 34.1397138,
+      "longitude": -117.9792387
+    }
+  },
+  "91010": {
+    "coordinates": {
+      "latitude": 34.1579788,
+      "longitude": -117.9424743
+    }
+  },
+  "91011": {
+    "coordinates": {
+      "latitude": 34.2133926,
+      "longitude": -118.1941785
+    }
+  },
+  "91012": {
+    "coordinates": {
+      "latitude": 34.21,
+      "longitude": -118.22
+    }
+  },
+  "91016": {
+    "coordinates": {
+      "latitude": 34.1574588,
+      "longitude": -118.0068979
+    }
+  },
+  "91017": {
+    "coordinates": {
+      "latitude": 34.15,
+      "longitude": -118
+    }
+  },
+  "91020": {
+    "coordinates": {
+      "latitude": 34.2115828,
+      "longitude": -118.2321952
+    }
+  },
+  "91021": {
+    "coordinates": {
+      "latitude": 34.21,
+      "longitude": -118.22
+    }
+  },
+  "91023": {
+    "coordinates": {
+      "latitude": 34.2276262,
+      "longitude": -118.0676991
+    }
+  },
+  "91024": {
+    "coordinates": {
+      "latitude": 34.1934312,
+      "longitude": -118.0478826
+    }
+  },
+  "91025": {
+    "coordinates": {
+      "latitude": 34.1599999,
+      "longitude": -118.05
+    }
+  },
+  "91030": {
+    "coordinates": {
+      "latitude": 34.1058277,
+      "longitude": -118.153228
+    }
+  },
+  "91031": {
+    "coordinates": {
+      "latitude": 34.12,
+      "longitude": -118.15
+    }
+  },
+  "91040": {
+    "coordinates": {
+      "latitude": 34.2864053,
+      "longitude": -118.3111262
+    }
+  },
+  "91041": {
+    "coordinates": {
+      "latitude": 34.27,
+      "longitude": -118.3
+    }
+  },
+  "91042": {
+    "coordinates": {
+      "latitude": 34.296676,
+      "longitude": -118.2292712
+    }
+  },
+  "91043": {
+    "coordinates": {
+      "latitude": 34.2499923,
+      "longitude": -118.2899871
+    }
+  },
+  "91046": {
+    "coordinates": {
+      "latitude": 34.211442,
+      "longitude": -118.240734
+    }
+  },
+  "91050": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "91051": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "91066": {
+    "coordinates": {
+      "latitude": 34.14,
+      "longitude": -118.03
+    }
+  },
+  "91077": {
+    "coordinates": {
+      "latitude": 34.13,
+      "longitude": -118.05
+    }
+  },
+  "91101": {
+    "coordinates": {
+      "latitude": 34.1427587,
+      "longitude": -118.1386005
+    }
+  },
+  "91102": {
+    "coordinates": {
+      "latitude": 34.1485194,
+      "longitude": -118.1419472
+    }
+  },
+  "91103": {
+    "coordinates": {
+      "latitude": 34.1672881,
+      "longitude": -118.153228
+    }
+  },
+  "91104": {
+    "coordinates": {
+      "latitude": 34.1657707,
+      "longitude": -118.1181199
+    }
+  },
+  "91105": {
+    "coordinates": {
+      "latitude": 34.1406082,
+      "longitude": -118.1678543
+    }
+  },
+  "91106": {
+    "coordinates": {
+      "latitude": 34.1456654,
+      "longitude": -118.1268976
+    }
+  },
+  "91107": {
+    "coordinates": {
+      "latitude": 34.16423960000001,
+      "longitude": -118.0830047
+    }
+  },
+  "91108": {
+    "coordinates": {
+      "latitude": 34.1247921,
+      "longitude": -118.1181199
+    }
+  },
+  "91109": {
+    "coordinates": {
+      "latitude": 34.1561783,
+      "longitude": -118.1528623
+    }
+  },
+  "91110": {
+    "coordinates": {
+      "latitude": 34.1599999,
+      "longitude": -118.15
+    }
+  },
+  "91114": {
+    "coordinates": {
+      "latitude": 34.17,
+      "longitude": -118.13
+    }
+  },
+  "91115": {
+    "coordinates": {
+      "latitude": 34.14,
+      "longitude": -118.15
+    }
+  },
+  "91116": {
+    "coordinates": {
+      "latitude": 34.1500196,
+      "longitude": -118.1296057
+    }
+  },
+  "91117": {
+    "coordinates": {
+      "latitude": 34.149491,
+      "longitude": -118.099449
+    }
+  },
+  "91118": {
+    "coordinates": {
+      "latitude": 34.12,
+      "longitude": -118.11
+    }
+  },
+  "91121": {
+    "coordinates": {
+      "latitude": 34.14916,
+      "longitude": -118.0895894
+    }
+  },
+  "91123": {
+    "coordinates": {
+      "latitude": 34.1426959,
+      "longitude": -118.1568847
+    }
+  },
+  "91124": {
+    "coordinates": {
+      "latitude": 34.1485444,
+      "longitude": -118.1539593
+    }
+  },
+  "91125": {
+    "coordinates": {
+      "latitude": 34.1378866,
+      "longitude": -118.1247032
+    }
+  },
+  "91126": {
+    "coordinates": {
+      "latitude": 34.1359544,
+      "longitude": -118.1242089
+    }
+  },
+  "91129": {
+    "coordinates": {
+      "latitude": 34.1445017,
+      "longitude": -118.1599559
+    }
+  },
+  "91131": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "91175": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "91182": {
+    "coordinates": {
+      "latitude": 34.1490265,
+      "longitude": -118.140429
+    }
+  },
+  "91184": {
+    "coordinates": {
+      "latitude": 34.138997,
+      "longitude": -118.1601756
+    }
+  },
+  "91185": {
+    "coordinates": {
+      "latitude": 34.1599999,
+      "longitude": -118.15
+    }
+  },
+  "91186": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "91187": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "91188": {
+    "coordinates": {
+      "latitude": 34.1505836,
+      "longitude": -118.1418918
+    }
+  },
+  "91189": {
+    "coordinates": {
+      "latitude": 34.1318458,
+      "longitude": -118.1477604
+    }
+  },
+  "91191": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "91201": {
+    "coordinates": {
+      "latitude": 34.1629905,
+      "longitude": -118.2935891
+    }
+  },
+  "91202": {
+    "coordinates": {
+      "latitude": 34.1688371,
+      "longitude": -118.2702036
+    }
+  },
+  "91203": {
+    "coordinates": {
+      "latitude": 34.1531191,
+      "longitude": -118.2614332
+    }
+  },
+  "91204": {
+    "coordinates": {
+      "latitude": 34.1377656,
+      "longitude": -118.2614332
+    }
+  },
+  "91205": {
+    "coordinates": {
+      "latitude": 34.1337367,
+      "longitude": -118.2468148
+    }
+  },
+  "91206": {
+    "coordinates": {
+      "latitude": 34.1527251,
+      "longitude": -118.2117257
+    }
+  },
+  "91207": {
+    "coordinates": {
+      "latitude": 34.1893001,
+      "longitude": -118.2702036
+    }
+  },
+  "91208": {
+    "coordinates": {
+      "latitude": 34.1980641,
+      "longitude": -118.2351192
+    }
+  },
+  "91209": {
+    "coordinates": {
+      "latitude": 34.1464871,
+      "longitude": -118.2518395
+    }
+  },
+  "91210": {
+    "coordinates": {
+      "latitude": 34.144801,
+      "longitude": -118.2563169
+    }
+  },
+  "91214": {
+    "coordinates": {
+      "latitude": 34.2389818,
+      "longitude": -118.2351192
+    }
+  },
+  "91221": {
+    "coordinates": {
+      "latitude": 34.1599999,
+      "longitude": -118.29
+    }
+  },
+  "91222": {
+    "coordinates": {
+      "latitude": 34.1599999,
+      "longitude": -118.26
+    }
+  },
+  "91224": {
+    "coordinates": {
+      "latitude": 34.2299999,
+      "longitude": -118.25
+    }
+  },
+  "91225": {
+    "coordinates": {
+      "latitude": 34.14,
+      "longitude": -118.25
+    }
+  },
+  "91226": {
+    "coordinates": {
+      "latitude": 34.1399918,
+      "longitude": -118.2499954
+    }
+  },
+  "91301": {
+    "coordinates": {
+      "latitude": 34.1129907,
+      "longitude": -118.754782
+    }
+  },
+  "91302": {
+    "coordinates": {
+      "latitude": 34.1307949,
+      "longitude": -118.6848112
+    }
+  },
+  "91303": {
+    "coordinates": {
+      "latitude": 34.1989453,
+      "longitude": -118.597305
+    }
+  },
+  "91304": {
+    "coordinates": {
+      "latitude": 34.2249609,
+      "longitude": -118.6556478
+    }
+  },
+  "91305": {
+    "coordinates": {
+      "latitude": 34.1998644,
+      "longitude": -118.599807
+    }
+  },
+  "91306": {
+    "coordinates": {
+      "latitude": 34.2048586,
+      "longitude": -118.5739621
+    }
+  },
+  "91307": {
+    "coordinates": {
+      "latitude": 34.2124444,
+      "longitude": -118.6848112
+    }
+  },
+  "91308": {
+    "coordinates": {
+      "latitude": 34.2,
+      "longitude": -118.64
+    }
+  },
+  "91309": {
+    "coordinates": {
+      "latitude": 34.22000000000001,
+      "longitude": -118.6
+    }
+  },
+  "91310": {
+    "coordinates": {
+      "latitude": 34.49,
+      "longitude": -118.62
+    }
+  },
+  "91311": {
+    "coordinates": {
+      "latitude": 34.2710376,
+      "longitude": -118.61481
+    }
+  },
+  "91312": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "91313": {
+    "coordinates": {
+      "latitude": 34.26,
+      "longitude": -118.6
+    }
+  },
+  "91316": {
+    "coordinates": {
+      "latitude": 34.1583323,
+      "longitude": -118.5155901
+    }
+  },
+  "91319": {
+    "coordinates": {
+      "latitude": 34.18,
+      "longitude": -118.91
+    }
+  },
+  "91320": {
+    "coordinates": {
+      "latitude": 34.1810666,
+      "longitude": -118.9470422
+    }
+  },
+  "91321": {
+    "coordinates": {
+      "latitude": 34.3677169,
+      "longitude": -118.4747173
+    }
+  },
+  "91322": {
+    "coordinates": {
+      "latitude": 34.3792628,
+      "longitude": -118.5473013
+    }
+  },
+  "91324": {
+    "coordinates": {
+      "latitude": 34.2413938,
+      "longitude": -118.5506158
+    }
+  },
+  "91325": {
+    "coordinates": {
+      "latitude": 34.2400436,
+      "longitude": -118.5155901
+    }
+  },
+  "91326": {
+    "coordinates": {
+      "latitude": 34.2894584,
+      "longitude": -118.5622893
+    }
+  },
+  "91327": {
+    "coordinates": {
+      "latitude": 34.27,
+      "longitude": -118.54
+    }
+  },
+  "91328": {
+    "coordinates": {
+      "latitude": 34.24,
+      "longitude": -118.54
+    }
+  },
+  "91329": {
+    "coordinates": {
+      "latitude": 34.2239055,
+      "longitude": -118.5024461
+    }
+  },
+  "91330": {
+    "coordinates": {
+      "latitude": 34.2489458,
+      "longitude": -118.5258067
+    }
+  },
+  "91331": {
+    "coordinates": {
+      "latitude": 34.2570374,
+      "longitude": -118.4279933
+    }
+  },
+  "91333": {
+    "coordinates": {
+      "latitude": 34.26,
+      "longitude": -118.43
+    }
+  },
+  "91334": {
+    "coordinates": {
+      "latitude": 34.26,
+      "longitude": -118.42
+    }
+  },
+  "91335": {
+    "coordinates": {
+      "latitude": 34.2035088,
+      "longitude": -118.5389414
+    }
+  },
+  "91337": {
+    "coordinates": {
+      "latitude": 34.2,
+      "longitude": -118.54
+    }
+  },
+  "91340": {
+    "coordinates": {
+      "latitude": 34.2913046,
+      "longitude": -118.4338345
+    }
+  },
+  "91341": {
+    "coordinates": {
+      "latitude": 34.28,
+      "longitude": -118.44
+    }
+  },
+  "91342": {
+    "coordinates": {
+      "latitude": 34.3023759,
+      "longitude": -118.3695699
+    }
+  },
+  "91343": {
+    "coordinates": {
+      "latitude": 34.2386799,
+      "longitude": -118.4805569
+    }
+  },
+  "91344": {
+    "coordinates": {
+      "latitude": 34.2801972,
+      "longitude": -118.4980744
+    }
+  },
+  "91345": {
+    "coordinates": {
+      "latitude": 34.264995,
+      "longitude": -118.4571974
+    }
+  },
+  "91346": {
+    "coordinates": {
+      "latitude": 34.27,
+      "longitude": -118.47
+    }
+  },
+  "91350": {
+    "coordinates": {
+      "latitude": 34.4338228,
+      "longitude": -118.5155901
+    }
+  },
+  "91351": {
+    "coordinates": {
+      "latitude": 34.4384112,
+      "longitude": -118.4571974
+    }
+  },
+  "91352": {
+    "coordinates": {
+      "latitude": 34.23015670000001,
+      "longitude": -118.3520389
+    }
+  },
+  "91353": {
+    "coordinates": {
+      "latitude": 34.22000000000001,
+      "longitude": -118.37
+    }
+  },
+  "91354": {
+    "coordinates": {
+      "latitude": 34.4627169,
+      "longitude": -118.5622893
+    }
+  },
+  "91355": {
+    "coordinates": {
+      "latitude": 34.4400287,
+      "longitude": -118.5914696
+    }
+  },
+  "91356": {
+    "coordinates": {
+      "latitude": 34.1662848,
+      "longitude": -118.5447787
+    }
+  },
+  "91357": {
+    "coordinates": {
+      "latitude": 34.17,
+      "longitude": -118.55
+    }
+  },
+  "91358": {
+    "coordinates": {
+      "latitude": 34.17,
+      "longitude": -118.84
+    }
+  },
+  "91359": {
+    "coordinates": {
+      "latitude": 34.17,
+      "longitude": -118.83
+    }
+  },
+  "91360": {
+    "coordinates": {
+      "latitude": 34.2024698,
+      "longitude": -118.8741429
+    }
+  },
+  "91361": {
+    "coordinates": {
+      "latitude": 34.1384626,
+      "longitude": -118.8946309
+    }
+  },
+  "91362": {
+    "coordinates": {
+      "latitude": 34.1971476,
+      "longitude": -118.824722
+    }
+  },
+  "91363": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "91364": {
+    "coordinates": {
+      "latitude": 34.1544724,
+      "longitude": -118.5914696
+    }
+  },
+  "91365": {
+    "coordinates": {
+      "latitude": 34.1693503,
+      "longitude": -118.6095343
+    }
+  },
+  "91367": {
+    "coordinates": {
+      "latitude": 34.1785255,
+      "longitude": -118.597305
+    }
+  },
+  "91371": {
+    "coordinates": {
+      "latitude": 34.1847736,
+      "longitude": -118.5827161
+    }
+  },
+  "91372": {
+    "coordinates": {
+      "latitude": 34.15,
+      "longitude": -118.64
+    }
+  },
+  "91376": {
+    "coordinates": {
+      "latitude": 34.14,
+      "longitude": -118.74
+    }
+  },
+  "91377": {
+    "coordinates": {
+      "latitude": 34.1880333,
+      "longitude": -118.7606115
+    }
+  },
+  "91380": {
+    "coordinates": {
+      "latitude": 34.5,
+      "longitude": -118.4
+    }
+  },
+  "91381": {
+    "coordinates": {
+      "latitude": 34.3729805,
+      "longitude": -118.61481
+    }
+  },
+  "91382": {
+    "coordinates": {
+      "latitude": 34.39,
+      "longitude": -118.54
+    }
+  },
+  "91383": {
+    "coordinates": {
+      "latitude": 34.43,
+      "longitude": -118.64
+    }
+  },
+  "91384": {
+    "coordinates": {
+      "latitude": 34.5455162,
+      "longitude": -118.6964752
+    }
+  },
+  "91385": {
+    "coordinates": {
+      "latitude": 34.39,
+      "longitude": -118.56
+    }
+  },
+  "91386": {
+    "coordinates": {
+      "latitude": 34.42,
+      "longitude": -118.45
+    }
+  },
+  "91387": {
+    "coordinates": {
+      "latitude": 34.41305699999999,
+      "longitude": -118.4163103
+    }
+  },
+  "91388": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "91390": {
+    "coordinates": {
+      "latitude": 34.4964601,
+      "longitude": -118.3346172
+    }
+  },
+  "91392": {
+    "coordinates": {
+      "latitude": 34.31,
+      "longitude": -118.45
+    }
+  },
+  "91393": {
+    "coordinates": {
+      "latitude": 34.1599999,
+      "longitude": -118.28
+    }
+  },
+  "91394": {
+    "coordinates": {
+      "latitude": 34.26,
+      "longitude": -118.52
+    }
+  },
+  "91395": {
+    "coordinates": {
+      "latitude": 34.26,
+      "longitude": -118.47
+    }
+  },
+  "91396": {
+    "coordinates": {
+      "latitude": 34.21,
+      "longitude": -118.57
+    }
+  },
+  "91399": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "91401": {
+    "coordinates": {
+      "latitude": 34.1789379,
+      "longitude": -118.4338345
+    }
+  },
+  "91402": {
+    "coordinates": {
+      "latitude": 34.2252697,
+      "longitude": -118.442596
+    }
+  },
+  "91403": {
+    "coordinates": {
+      "latitude": 34.1423899,
+      "longitude": -118.4571974
+    }
+  },
+  "91404": {
+    "coordinates": {
+      "latitude": 34.1826777,
+      "longitude": -118.4486457
+    }
+  },
+  "91405": {
+    "coordinates": {
+      "latitude": 34.2037124,
+      "longitude": -118.4571974
+    }
+  },
+  "91406": {
+    "coordinates": {
+      "latitude": 34.1985119,
+      "longitude": -118.4980744
+    }
+  },
+  "91407": {
+    "coordinates": {
+      "latitude": 34.1826777,
+      "longitude": -118.4486457
+    }
+  },
+  "91408": {
+    "coordinates": {
+      "latitude": 34.1826777,
+      "longitude": -118.4486457
+    }
+  },
+  "91409": {
+    "coordinates": {
+      "latitude": 34.2011137,
+      "longitude": -118.475058
+    }
+  },
+  "91410": {
+    "coordinates": {
+      "latitude": 34.2,
+      "longitude": -118.47
+    }
+  },
+  "91411": {
+    "coordinates": {
+      "latitude": 34.1799855,
+      "longitude": -118.4601175
+    }
+  },
+  "91412": {
+    "coordinates": {
+      "latitude": 34.22000000000001,
+      "longitude": -118.45
+    }
+  },
+  "91413": {
+    "coordinates": {
+      "latitude": 34.1599999,
+      "longitude": -118.46
+    }
+  },
+  "91416": {
+    "coordinates": {
+      "latitude": 34.18,
+      "longitude": -118.52
+    }
+  },
+  "91423": {
+    "coordinates": {
+      "latitude": 34.1482691,
+      "longitude": -118.4338345
+    }
+  },
+  "91426": {
+    "coordinates": {
+      "latitude": 34.1599999,
+      "longitude": -118.5
+    }
+  },
+  "91436": {
+    "coordinates": {
+      "latitude": 34.1540054,
+      "longitude": -118.4922355
+    }
+  },
+  "91470": {
+    "coordinates": {
+      "latitude": 34.2,
+      "longitude": -118.47
+    }
+  },
+  "91482": {
+    "coordinates": {
+      "latitude": 34.2,
+      "longitude": -118.47
+    }
+  },
+  "91495": {
+    "coordinates": {
+      "latitude": 34.2,
+      "longitude": -118.47
+    }
+  },
+  "91496": {
+    "coordinates": {
+      "latitude": 34.2,
+      "longitude": -118.47
+    }
+  },
+  "91497": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "91499": {
+    "coordinates": {
+      "latitude": 34.2,
+      "longitude": -118.47
+    }
+  },
+  "91501": {
+    "coordinates": {
+      "latitude": 34.2039087,
+      "longitude": -118.2935891
+    }
+  },
+  "91502": {
+    "coordinates": {
+      "latitude": 34.1772371,
+      "longitude": -118.3082034
+    }
+  },
+  "91503": {
+    "coordinates": {
+      "latitude": 34.1872813,
+      "longitude": -118.3489963
+    }
+  },
+  "91504": {
+    "coordinates": {
+      "latitude": 34.2053511,
+      "longitude": -118.3286614
+    }
+  },
+  "91505": {
+    "coordinates": {
+      "latitude": 34.1615135,
+      "longitude": -118.3403506
+    }
+  },
+  "91506": {
+    "coordinates": {
+      "latitude": 34.1728461,
+      "longitude": -118.325739
+    }
+  },
+  "91507": {
+    "coordinates": {
+      "latitude": 34.1699956,
+      "longitude": -118.3499537
+    }
+  },
+  "91508": {
+    "coordinates": {
+      "latitude": 34.189976,
+      "longitude": -118.3299925
+    }
+  },
+  "91510": {
+    "coordinates": {
+      "latitude": 34.19,
+      "longitude": -118.35
+    }
+  },
+  "91521": {
+    "coordinates": {
+      "latitude": 34.1568172,
+      "longitude": -118.3246431
+    }
+  },
+  "91522": {
+    "coordinates": {
+      "latitude": 34.1483152,
+      "longitude": -118.3407158
+    }
+  },
+  "91523": {
+    "coordinates": {
+      "latitude": 34.1548495,
+      "longitude": -118.3337755
+    }
+  },
+  "91526": {
+    "coordinates": {
+      "latitude": 34.17,
+      "longitude": -118.35
+    }
+  },
+  "91601": {
+    "coordinates": {
+      "latitude": 34.1658804,
+      "longitude": -118.3637264
+    }
+  },
+  "91602": {
+    "coordinates": {
+      "latitude": 34.1487141,
+      "longitude": -118.3608046
+    }
+  },
+  "91603": {
+    "coordinates": {
+      "latitude": 34.1680031,
+      "longitude": -118.3777395
+    }
+  },
+  "91604": {
+    "coordinates": {
+      "latitude": 34.1366259,
+      "longitude": -118.3987842
+    }
+  },
+  "91605": {
+    "coordinates": {
+      "latitude": 34.208195,
+      "longitude": -118.3987842
+    }
+  },
+  "91606": {
+    "coordinates": {
+      "latitude": 34.1873985,
+      "longitude": -118.3900204
+    }
+  },
+  "91607": {
+    "coordinates": {
+      "latitude": 34.167305,
+      "longitude": -118.3987842
+    }
+  },
+  "91608": {
+    "coordinates": {
+      "latitude": 34.13610070000001,
+      "longitude": -118.3519973
+    }
+  },
+  "91609": {
+    "coordinates": {
+      "latitude": 34.1893,
+      "longitude": -118.3878446
+    }
+  },
+  "91610": {
+    "coordinates": {
+      "latitude": 34.15999480000001,
+      "longitude": -118.3798111
+    }
+  },
+  "91611": {
+    "coordinates": {
+      "latitude": 34.1866201,
+      "longitude": -118.3965122
+    }
+  },
+  "91612": {
+    "coordinates": {
+      "latitude": 34.1866201,
+      "longitude": -118.3965122
+    }
+  },
+  "91614": {
+    "coordinates": {
+      "latitude": 34.15,
+      "longitude": -118.4
+    }
+  },
+  "91615": {
+    "coordinates": {
+      "latitude": 34.2,
+      "longitude": -118.4
+    }
+  },
+  "91616": {
+    "coordinates": {
+      "latitude": 34.18,
+      "longitude": -118.4
+    }
+  },
+  "91617": {
+    "coordinates": {
+      "latitude": 34.1599999,
+      "longitude": -118.4
+    }
+  },
+  "91618": {
+    "coordinates": {
+      "latitude": 34.14,
+      "longitude": -118.35
+    }
+  },
+  "91671": {
+    "coordinates": {
+      "latitude": 34.175205,
+      "longitude": -118.382212
+    }
+  },
+  "91701": {
+    "coordinates": {
+      "latitude": 34.13566730000001,
+      "longitude": -117.6141457
+    }
+  },
+  "91702": {
+    "coordinates": {
+      "latitude": 34.2667473,
+      "longitude": -117.8545867
+    }
+  },
+  "91706": {
+    "coordinates": {
+      "latitude": 34.0812006,
+      "longitude": -117.9834738
+    }
+  },
+  "91708": {
+    "coordinates": {
+      "latitude": 33.9522626,
+      "longitude": -117.6493515
+    }
+  },
+  "91709": {
+    "coordinates": {
+      "latitude": 33.959453,
+      "longitude": -117.7256083
+    }
+  },
+  "91710": {
+    "coordinates": {
+      "latitude": 34.0120229,
+      "longitude": -117.6786847
+    }
+  },
+  "91711": {
+    "coordinates": {
+      "latitude": 34.1707374,
+      "longitude": -117.702148
+    }
+  },
+  "91714": {
+    "coordinates": {
+      "latitude": 34.02,
+      "longitude": -117.96
+    }
+  },
+  "91715": {
+    "coordinates": {
+      "latitude": 34.0153681,
+      "longitude": -117.9703455
+    }
+  },
+  "91716": {
+    "coordinates": {
+      "latitude": 34.02,
+      "longitude": -117.96
+    }
+  },
+  "91718": {
+    "coordinates": {
+      "latitude": 33.752886,
+      "longitude": -116.055617
+    }
+  },
+  "91719": {
+    "coordinates": {
+      "latitude": 33.735688,
+      "longitude": -117.42049
+    }
+  },
+  "91720": {
+    "coordinates": {
+      "latitude": 33.752886,
+      "longitude": -116.055617
+    }
+  },
+  "91722": {
+    "coordinates": {
+      "latitude": 34.0948204,
+      "longitude": -117.9073244
+    }
+  },
+  "91723": {
+    "coordinates": {
+      "latitude": 34.0870296,
+      "longitude": -117.8868171
+    }
+  },
+  "91724": {
+    "coordinates": {
+      "latitude": 34.0858034,
+      "longitude": -117.8604472
+    }
+  },
+  "91729": {
+    "coordinates": {
+      "latitude": 34.099175,
+      "longitude": -117.5639339
+    }
+  },
+  "91730": {
+    "coordinates": {
+      "latitude": 34.0965313,
+      "longitude": -117.5848025
+    }
+  },
+  "91731": {
+    "coordinates": {
+      "latitude": 34.0835771,
+      "longitude": -118.0361736
+    }
+  },
+  "91732": {
+    "coordinates": {
+      "latitude": 34.0791053,
+      "longitude": -118.0127534
+    }
+  },
+  "91733": {
+    "coordinates": {
+      "latitude": 34.0499095,
+      "longitude": -118.0478826
+    }
+  },
+  "91734": {
+    "coordinates": {
+      "latitude": 34.0749394,
+      "longitude": -118.0341611
+    }
+  },
+  "91735": {
+    "coordinates": {
+      "latitude": 34.07,
+      "longitude": -118.03
+    }
+  },
+  "91737": {
+    "coordinates": {
+      "latitude": 34.1787581,
+      "longitude": -117.5848025
+    }
+  },
+  "91739": {
+    "coordinates": {
+      "latitude": 34.1547243,
+      "longitude": -117.5143603
+    }
+  },
+  "91740": {
+    "coordinates": {
+      "latitude": 34.1194758,
+      "longitude": -117.848726
+    }
+  },
+  "91741": {
+    "coordinates": {
+      "latitude": 34.1568319,
+      "longitude": -117.8428651
+    }
+  },
+  "91743": {
+    "coordinates": {
+      "latitude": 34.0646405,
+      "longitude": -117.5845265
+    }
+  },
+  "91744": {
+    "coordinates": {
+      "latitude": 34.0274622,
+      "longitude": -117.9307584
+    }
+  },
+  "91745": {
+    "coordinates": {
+      "latitude": 33.9990858,
+      "longitude": -117.9834738
+    }
+  },
+  "91746": {
+    "coordinates": {
+      "latitude": 34.0541034,
+      "longitude": -117.9893301
+    }
+  },
+  "91747": {
+    "coordinates": {
+      "latitude": 34.0373357,
+      "longitude": -117.9519585
+    }
+  },
+  "91748": {
+    "coordinates": {
+      "latitude": 33.9810337,
+      "longitude": -117.8897468
+    }
+  },
+  "91749": {
+    "coordinates": {
+      "latitude": 34.0218507,
+      "longitude": -117.956279
+    }
+  },
+  "91750": {
+    "coordinates": {
+      "latitude": 34.1945949,
+      "longitude": -117.77252
+    }
+  },
+  "91752": {
+    "coordinates": {
+      "latitude": 34.0050096,
+      "longitude": -117.5378439
+    }
+  },
+  "91754": {
+    "coordinates": {
+      "latitude": 34.0472318,
+      "longitude": -118.1415261
+    }
+  },
+  "91755": {
+    "coordinates": {
+      "latitude": 34.0427819,
+      "longitude": -118.1181199
+    }
+  },
+  "91756": {
+    "coordinates": {
+      "latitude": 34.0435816,
+      "longitude": -118.1411981
+    }
+  },
+  "91758": {
+    "coordinates": {
+      "latitude": 34.06,
+      "longitude": -117.62
+    }
+  },
+  "91759": {
+    "coordinates": {
+      "latitude": 34.2602336,
+      "longitude": -117.7138785
+    }
+  },
+  "91760": {
+    "coordinates": {
+      "latitude": 33.752886,
+      "longitude": -116.055617
+    }
+  },
+  "91761": {
+    "coordinates": {
+      "latitude": 34.0348144,
+      "longitude": -117.5848025
+    }
+  },
+  "91762": {
+    "coordinates": {
+      "latitude": 34.0420153,
+      "longitude": -117.6610854
+    }
+  },
+  "91763": {
+    "coordinates": {
+      "latitude": 34.0745742,
+      "longitude": -117.6962824
+    }
+  },
+  "91764": {
+    "coordinates": {
+      "latitude": 34.0739866,
+      "longitude": -117.6141457
+    }
+  },
+  "91765": {
+    "coordinates": {
+      "latitude": 33.9945546,
+      "longitude": -117.8135579
+    }
+  },
+  "91766": {
+    "coordinates": {
+      "latitude": 34.0397162,
+      "longitude": -117.7549295
+    }
+  },
+  "91767": {
+    "coordinates": {
+      "latitude": 34.0836851,
+      "longitude": -117.7432015
+    }
+  },
+  "91768": {
+    "coordinates": {
+      "latitude": 34.0648167,
+      "longitude": -117.7783831
+    }
+  },
+  "91769": {
+    "coordinates": {
+      "latitude": 34.0602708,
+      "longitude": -117.758368
+    }
+  },
+  "91770": {
+    "coordinates": {
+      "latitude": 34.06173649999999,
+      "longitude": -118.0830047
+    }
+  },
+  "91771": {
+    "coordinates": {
+      "latitude": 34.08,
+      "longitude": -118.08
+    }
+  },
+  "91772": {
+    "coordinates": {
+      "latitude": 34.08,
+      "longitude": -118.08
+    }
+  },
+  "91773": {
+    "coordinates": {
+      "latitude": 34.1009953,
+      "longitude": -117.8194197
+    }
+  },
+  "91775": {
+    "coordinates": {
+      "latitude": 34.1232517,
+      "longitude": -118.0830047
+    }
+  },
+  "91776": {
+    "coordinates": {
+      "latitude": 34.0895991,
+      "longitude": -118.0947106
+    }
+  },
+  "91778": {
+    "coordinates": {
+      "latitude": 34.1023978,
+      "longitude": -118.0995912
+    }
+  },
+  "91780": {
+    "coordinates": {
+      "latitude": 34.0982956,
+      "longitude": -118.0595907
+    }
+  },
+  "91784": {
+    "coordinates": {
+      "latitude": 34.1616368,
+      "longitude": -117.6552185
+    }
+  },
+  "91785": {
+    "coordinates": {
+      "latitude": 34.0952311,
+      "longitude": -117.6734931
+    }
+  },
+  "91786": {
+    "coordinates": {
+      "latitude": 34.1036996,
+      "longitude": -117.6610854
+    }
+  },
+  "91788": {
+    "coordinates": {
+      "latitude": 34.0158944,
+      "longitude": -117.8640942
+    }
+  },
+  "91789": {
+    "coordinates": {
+      "latitude": 34.0130769,
+      "longitude": -117.8428651
+    }
+  },
+  "91790": {
+    "coordinates": {
+      "latitude": 34.0656464,
+      "longitude": -117.9424743
+    }
+  },
+  "91791": {
+    "coordinates": {
+      "latitude": 34.0566376,
+      "longitude": -117.8956062
+    }
+  },
+  "91792": {
+    "coordinates": {
+      "latitude": 34.0332214,
+      "longitude": -117.9073244
+    }
+  },
+  "91793": {
+    "coordinates": {
+      "latitude": 34.068839,
+      "longitude": -117.9281954
+    }
+  },
+  "91795": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "91797": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "91798": {
+    "coordinates": {
+      "latitude": 34.839964,
+      "longitude": -115.967051
+    }
+  },
+  "91799": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "91801": {
+    "coordinates": {
+      "latitude": 34.0837958,
+      "longitude": -118.1181199
+    }
+  },
+  "91802": {
+    "coordinates": {
+      "latitude": 34.0923467,
+      "longitude": -118.1256175
+    }
+  },
+  "91803": {
+    "coordinates": {
+      "latitude": 34.0779881,
+      "longitude": -118.1415261
+    }
+  },
+  "91804": {
+    "coordinates": {
+      "latitude": 34.1,
+      "longitude": -118.13
+    }
+  },
+  "91841": {
+    "coordinates": {
+      "latitude": 33.786594,
+      "longitude": -118.298662
+    }
+  },
+  "91896": {
+    "coordinates": {
+      "latitude": 34.09,
+      "longitude": -118.12
+    }
+  },
+  "91899": {
+    "coordinates": {
+      "latitude": 34.09,
+      "longitude": -118.12
+    }
+  },
+  "91901": {
+    "coordinates": {
+      "latitude": 32.83630900000001,
+      "longitude": -116.7260713
+    }
+  },
+  "91902": {
+    "coordinates": {
+      "latitude": 32.6703579,
+      "longitude": -117.0146736
+    }
+  },
+  "91903": {
+    "coordinates": {
+      "latitude": 32.84,
+      "longitude": -116.77
+    }
+  },
+  "91905": {
+    "coordinates": {
+      "latitude": 32.6810703,
+      "longitude": -116.3013267
+    }
+  },
+  "91906": {
+    "coordinates": {
+      "latitude": 32.6804705,
+      "longitude": -116.4901981
+    }
+  },
+  "91908": {
+    "coordinates": {
+      "latitude": 32.6692403,
+      "longitude": -117.0212138
+    }
+  },
+  "91909": {
+    "coordinates": {
+      "latitude": 32.6254698,
+      "longitude": -117.0745859
+    }
+  },
+  "91910": {
+    "coordinates": {
+      "latitude": 32.6385134,
+      "longitude": -117.0617553
+    }
+  },
+  "91911": {
+    "coordinates": {
+      "latitude": 32.6059744,
+      "longitude": -117.0441009
+    }
+  },
+  "91912": {
+    "coordinates": {
+      "latitude": 32.6249798,
+      "longitude": -117.0143058
+    }
+  },
+  "91913": {
+    "coordinates": {
+      "latitude": 32.6168755,
+      "longitude": -116.9970153
+    }
+  },
+  "91914": {
+    "coordinates": {
+      "latitude": 32.6762339,
+      "longitude": -116.9440313
+    }
+  },
+  "91915": {
+    "coordinates": {
+      "latitude": 32.6277588,
+      "longitude": -116.9499191
+    }
+  },
+  "91916": {
+    "coordinates": {
+      "latitude": 32.8997738,
+      "longitude": -116.6317514
+    }
+  },
+  "91917": {
+    "coordinates": {
+      "latitude": 32.6136117,
+      "longitude": -116.7378585
+    }
+  },
+  "91921": {
+    "coordinates": {
+      "latitude": 32.62,
+      "longitude": -117.01
+    }
+  },
+  "91927": {
+    "coordinates": {
+      "latitude": 32.701452,
+      "longitude": -117.002054
+    }
+  },
+  "91931": {
+    "coordinates": {
+      "latitude": 32.8189976,
+      "longitude": -116.5727815
+    }
+  },
+  "91932": {
+    "coordinates": {
+      "latitude": 32.5829894,
+      "longitude": -117.1205925
+    }
+  },
+  "91933": {
+    "coordinates": {
+      "latitude": 32.5825738,
+      "longitude": -117.1134786
+    }
+  },
+  "91934": {
+    "coordinates": {
+      "latitude": 32.65233430000001,
+      "longitude": -116.1950214
+    }
+  },
+  "91935": {
+    "coordinates": {
+      "latitude": 32.6890231,
+      "longitude": -116.8203511
+    }
+  },
+  "91941": {
+    "coordinates": {
+      "latitude": 32.7699547,
+      "longitude": -116.9911288
+    }
+  },
+  "91942": {
+    "coordinates": {
+      "latitude": 32.7749487,
+      "longitude": -117.0146736
+    }
+  },
+  "91943": {
+    "coordinates": {
+      "latitude": 32.77,
+      "longitude": -117.02
+    }
+  },
+  "91944": {
+    "coordinates": {
+      "latitude": 32.77,
+      "longitude": -117.02
+    }
+  },
+  "91945": {
+    "coordinates": {
+      "latitude": 32.7381191,
+      "longitude": -117.0382158
+    }
+  },
+  "91946": {
+    "coordinates": {
+      "latitude": 32.7428016,
+      "longitude": -117.027808
+    }
+  },
+  "91947": {
+    "coordinates": {
+      "latitude": 33.016928,
+      "longitude": -116.846046
+    }
+  },
+  "91948": {
+    "coordinates": {
+      "latitude": 32.8721241,
+      "longitude": -116.431192
+    }
+  },
+  "91950": {
+    "coordinates": {
+      "latitude": 32.6721599,
+      "longitude": -117.0970596
+    }
+  },
+  "91951": {
+    "coordinates": {
+      "latitude": 32.6709088,
+      "longitude": -117.0969223
+    }
+  },
+  "91962": {
+    "coordinates": {
+      "latitude": 32.7750935,
+      "longitude": -116.4429944
+    }
+  },
+  "91963": {
+    "coordinates": {
+      "latitude": 32.6590536,
+      "longitude": -116.5845767
+    }
+  },
+  "91976": {
+    "coordinates": {
+      "latitude": 32.74,
+      "longitude": -117
+    }
+  },
+  "91977": {
+    "coordinates": {
+      "latitude": 32.7215291,
+      "longitude": -116.9970153
+    }
+  },
+  "91978": {
+    "coordinates": {
+      "latitude": 32.7258378,
+      "longitude": -116.9558067
+    }
+  },
+  "91979": {
+    "coordinates": {
+      "latitude": 32.7316347,
+      "longitude": -116.9723156
+    }
+  },
+  "91980": {
+    "coordinates": {
+      "latitude": 32.5841377,
+      "longitude": -116.6140621
+    }
+  },
+  "91987": {
+    "coordinates": {
+      "latitude": 32.58,
+      "longitude": -116.63
+    }
+  },
+  "91990": {
+    "coordinates": {
+      "latitude": 33.016928,
+      "longitude": -116.846046
+    }
+  },
+  "92002": {
+    "coordinates": {
+      "latitude": 33.198032,
+      "longitude": -117.234701
+    }
+  },
+  "92003": {
+    "coordinates": {
+      "latitude": 33.2822878,
+      "longitude": -117.185294
+    }
+  },
+  "92004": {
+    "coordinates": {
+      "latitude": 33.2566501,
+      "longitude": -116.3749797
+    }
+  },
+  "92007": {
+    "coordinates": {
+      "latitude": 33.0170252,
+      "longitude": -117.2734901
+    }
+  },
+  "92008": {
+    "coordinates": {
+      "latitude": 33.1412124,
+      "longitude": -117.3205123
+    }
+  },
+  "92009": {
+    "coordinates": {
+      "latitude": 33.095442,
+      "longitude": -117.2499749
+    }
+  },
+  "92013": {
+    "coordinates": {
+      "latitude": 33.1,
+      "longitude": -117.28
+    }
+  },
+  "92014": {
+    "coordinates": {
+      "latitude": 32.9864215,
+      "longitude": -117.226457
+    }
+  },
+  "92018": {
+    "coordinates": {
+      "latitude": 33.1594766,
+      "longitude": -117.3494974
+    }
+  },
+  "92019": {
+    "coordinates": {
+      "latitude": 32.7751095,
+      "longitude": -116.8556955
+    }
+  },
+  "92020": {
+    "coordinates": {
+      "latitude": 32.79632220000001,
+      "longitude": -116.9675814
+    }
+  },
+  "92021": {
+    "coordinates": {
+      "latitude": 32.8324351,
+      "longitude": -116.8792553
+    }
+  },
+  "92022": {
+    "coordinates": {
+      "latitude": 32.79,
+      "longitude": -116.97
+    }
+  },
+  "92023": {
+    "coordinates": {
+      "latitude": 33.060208,
+      "longitude": -117.2657906
+    }
+  },
+  "92024": {
+    "coordinates": {
+      "latitude": 33.052083,
+      "longitude": -117.2793685
+    }
+  },
+  "92025": {
+    "coordinates": {
+      "latitude": 33.090285,
+      "longitude": -117.0499859
+    }
+  },
+  "92026": {
+    "coordinates": {
+      "latitude": 33.2156978,
+      "longitude": -117.1147095
+    }
+  },
+  "92027": {
+    "coordinates": {
+      "latitude": 33.1467885,
+      "longitude": -117.0087877
+    }
+  },
+  "92028": {
+    "coordinates": {
+      "latitude": 33.3826505,
+      "longitude": -117.2440957
+    }
+  },
+  "92029": {
+    "coordinates": {
+      "latitude": 33.0852605,
+      "longitude": -117.1382404
+    }
+  },
+  "92030": {
+    "coordinates": {
+      "latitude": 33.13571659999999,
+      "longitude": -117.0558233
+    }
+  },
+  "92031": {
+    "coordinates": {
+      "latitude": 34.587473,
+      "longitude": -117.406293
+    }
+  },
+  "92033": {
+    "coordinates": {
+      "latitude": 33.12,
+      "longitude": -117.09
+    }
+  },
+  "92036": {
+    "coordinates": {
+      "latitude": 33.0157829,
+      "longitude": -116.4901981
+    }
+  },
+  "92037": {
+    "coordinates": {
+      "latitude": 32.8283259,
+      "longitude": -117.255854
+    }
+  },
+  "92038": {
+    "coordinates": {
+      "latitude": 32.8470987,
+      "longitude": -117.2727893
+    }
+  },
+  "92039": {
+    "coordinates": {
+      "latitude": 32.8470987,
+      "longitude": -117.2727893
+    }
+  },
+  "92040": {
+    "coordinates": {
+      "latitude": 32.8765334,
+      "longitude": -116.9145901
+    }
+  },
+  "92046": {
+    "coordinates": {
+      "latitude": 33.1248727,
+      "longitude": -117.1027794
+    }
+  },
+  "92049": {
+    "coordinates": {
+      "latitude": 33.1950781,
+      "longitude": -117.378631
+    }
+  },
+  "92051": {
+    "coordinates": {
+      "latitude": 33.1950781,
+      "longitude": -117.378631
+    }
+  },
+  "92052": {
+    "coordinates": {
+      "latitude": 33.1950781,
+      "longitude": -117.378631
+    }
+  },
+  "92054": {
+    "coordinates": {
+      "latitude": 33.1924489,
+      "longitude": -117.3675233
+    }
+  },
+  "92055": {
+    "coordinates": {
+      "latitude": 33.4209412,
+      "longitude": -117.4321452
+    }
+  },
+  "92056": {
+    "coordinates": {
+      "latitude": 33.192168,
+      "longitude": -117.3028803
+    }
+  },
+  "92057": {
+    "coordinates": {
+      "latitude": 33.260081,
+      "longitude": -117.2793685
+    }
+  },
+  "92058": {
+    "coordinates": {
+      "latitude": 33.2773221,
+      "longitude": -117.3381427
+    }
+  },
+  "92059": {
+    "coordinates": {
+      "latitude": 33.3930888,
+      "longitude": -117.0676398
+    }
+  },
+  "92060": {
+    "coordinates": {
+      "latitude": 33.353962,
+      "longitude": -116.8792553
+    }
+  },
+  "92061": {
+    "coordinates": {
+      "latitude": 33.3243386,
+      "longitude": -116.9616941
+    }
+  },
+  "92064": {
+    "coordinates": {
+      "latitude": 32.9799762,
+      "longitude": -117.0087877
+    }
+  },
+  "92065": {
+    "coordinates": {
+      "latitude": 33.0654286,
+      "longitude": -116.8203511
+    }
+  },
+  "92066": {
+    "coordinates": {
+      "latitude": 33.2248091,
+      "longitude": -116.4901981
+    }
+  },
+  "92067": {
+    "coordinates": {
+      "latitude": 33.0176773,
+      "longitude": -117.226457
+    }
+  },
+  "92068": {
+    "coordinates": {
+      "latitude": 33.29,
+      "longitude": -117.31
+    }
+  },
+  "92069": {
+    "coordinates": {
+      "latitude": 33.1630271,
+      "longitude": -117.1617685
+    }
+  },
+  "92070": {
+    "coordinates": {
+      "latitude": 33.2123927,
+      "longitude": -116.7260713
+    }
+  },
+  "92071": {
+    "coordinates": {
+      "latitude": 32.8678728,
+      "longitude": -116.9970153
+    }
+  },
+  "92072": {
+    "coordinates": {
+      "latitude": 32.8387387,
+      "longitude": -116.990876
+    }
+  },
+  "92074": {
+    "coordinates": {
+      "latitude": 32.9600006,
+      "longitude": -117.0400081
+    }
+  },
+  "92075": {
+    "coordinates": {
+      "latitude": 32.9956666,
+      "longitude": -117.2646723
+    }
+  },
+  "92078": {
+    "coordinates": {
+      "latitude": 33.1158665,
+      "longitude": -117.185294
+    }
+  },
+  "92079": {
+    "coordinates": {
+      "latitude": 33.14,
+      "longitude": -117.17
+    }
+  },
+  "92082": {
+    "coordinates": {
+      "latitude": 33.2300939,
+      "longitude": -117.0087877
+    }
+  },
+  "92083": {
+    "coordinates": {
+      "latitude": 33.2013734,
+      "longitude": -117.2529145
+    }
+  },
+  "92084": {
+    "coordinates": {
+      "latitude": 33.2143717,
+      "longitude": -117.2088167
+    }
+  },
+  "92085": {
+    "coordinates": {
+      "latitude": 33.2217739,
+      "longitude": -117.226056
+    }
+  },
+  "92086": {
+    "coordinates": {
+      "latitude": 33.3066657,
+      "longitude": -116.6789163
+    }
+  },
+  "92088": {
+    "coordinates": {
+      "latitude": 33.3761512,
+      "longitude": -117.2536784
+    }
+  },
+  "92090": {
+    "coordinates": {
+      "latitude": 33.016928,
+      "longitude": -116.846046
+    }
+  },
+  "92091": {
+    "coordinates": {
+      "latitude": 33.04680030000001,
+      "longitude": -117.1911749
+    }
+  },
+  "92092": {
+    "coordinates": {
+      "latitude": 32.88,
+      "longitude": -117.24
+    }
+  },
+  "92093": {
+    "coordinates": {
+      "latitude": 32.88435520000001,
+      "longitude": -117.2338066
+    }
+  },
+  "92096": {
+    "coordinates": {
+      "latitude": 33.1352287,
+      "longitude": -117.1610333
+    }
+  },
+  "92101": {
+    "coordinates": {
+      "latitude": 32.7269669,
+      "longitude": -117.1647094
+    }
+  },
+  "92102": {
+    "coordinates": {
+      "latitude": 32.7162223,
+      "longitude": -117.1323579
+    }
+  },
+  "92103": {
+    "coordinates": {
+      "latitude": 32.749789,
+      "longitude": -117.1676501
+    }
+  },
+  "92104": {
+    "coordinates": {
+      "latitude": 32.7398671,
+      "longitude": -117.1205925
+    }
+  },
+  "92105": {
+    "coordinates": {
+      "latitude": 32.7348953,
+      "longitude": -117.0970596
+    }
+  },
+  "92106": {
+    "coordinates": {
+      "latitude": 32.7090984,
+      "longitude": -117.241156
+    }
+  },
+  "92107": {
+    "coordinates": {
+      "latitude": 32.7409782,
+      "longitude": -117.2499749
+    }
+  },
+  "92108": {
+    "coordinates": {
+      "latitude": 32.7742488,
+      "longitude": -117.1411815
+    }
+  },
+  "92109": {
+    "coordinates": {
+      "latitude": 32.7920948,
+      "longitude": -117.2323367
+    }
+  },
+  "92110": {
+    "coordinates": {
+      "latitude": 32.7657318,
+      "longitude": -117.199996
+    }
+  },
+  "92111": {
+    "coordinates": {
+      "latitude": 32.8256427,
+      "longitude": -117.1558867
+    }
+  },
+  "92112": {
+    "coordinates": {
+      "latitude": 32.7198551,
+      "longitude": -117.1600022
+    }
+  },
+  "92113": {
+    "coordinates": {
+      "latitude": 32.6980553,
+      "longitude": -117.1205925
+    }
+  },
+  "92114": {
+    "coordinates": {
+      "latitude": 32.7040143,
+      "longitude": -117.0499859
+    }
+  },
+  "92115": {
+    "coordinates": {
+      "latitude": 32.7612759,
+      "longitude": -117.0735241
+    }
+  },
+  "92116": {
+    "coordinates": {
+      "latitude": 32.7679176,
+      "longitude": -117.1235339
+    }
+  },
+  "92117": {
+    "coordinates": {
+      "latitude": 32.8250767,
+      "longitude": -117.2029363
+    }
+  },
+  "92118": {
+    "coordinates": {
+      "latitude": 32.6920499,
+      "longitude": -117.1911749
+    }
+  },
+  "92119": {
+    "coordinates": {
+      "latitude": 32.8112871,
+      "longitude": -117.0382158
+    }
+  },
+  "92120": {
+    "coordinates": {
+      "latitude": 32.7926264,
+      "longitude": -117.0735241
+    }
+  },
+  "92121": {
+    "coordinates": {
+      "latitude": 32.8981142,
+      "longitude": -117.2029363
+    }
+  },
+  "92122": {
+    "coordinates": {
+      "latitude": 32.8563846,
+      "longitude": -117.2029363
+    }
+  },
+  "92123": {
+    "coordinates": {
+      "latitude": 32.8102534,
+      "longitude": -117.1323579
+    }
+  },
+  "92124": {
+    "coordinates": {
+      "latitude": 32.8250787,
+      "longitude": -117.091176
+    }
+  },
+  "92126": {
+    "coordinates": {
+      "latitude": 32.9184763,
+      "longitude": -117.1382404
+    }
+  },
+  "92127": {
+    "coordinates": {
+      "latitude": 33.0227476,
+      "longitude": -117.1382404
+    }
+  },
+  "92128": {
+    "coordinates": {
+      "latitude": 33.0013938,
+      "longitude": -117.0735241
+    }
+  },
+  "92129": {
+    "coordinates": {
+      "latitude": 32.9657005,
+      "longitude": -117.1147095
+    }
+  },
+  "92130": {
+    "coordinates": {
+      "latitude": 32.9436607,
+      "longitude": -117.2088167
+    }
+  },
+  "92131": {
+    "coordinates": {
+      "latitude": 32.8932137,
+      "longitude": -117.0676398
+    }
+  },
+  "92132": {
+    "coordinates": {
+      "latitude": 32.7150419,
+      "longitude": -117.1724288
+    }
+  },
+  "92133": {
+    "coordinates": {
+      "latitude": 32.733507,
+      "longitude": -117.216451
+    }
+  },
+  "92134": {
+    "coordinates": {
+      "latitude": 32.7240705,
+      "longitude": -117.1463285
+    }
+  },
+  "92135": {
+    "coordinates": {
+      "latitude": 32.70099,
+      "longitude": -117.20864
+    }
+  },
+  "92136": {
+    "coordinates": {
+      "latitude": 32.6833364,
+      "longitude": -117.1220632
+    }
+  },
+  "92137": {
+    "coordinates": {
+      "latitude": 32.75,
+      "longitude": -117.2
+    }
+  },
+  "92138": {
+    "coordinates": {
+      "latitude": 32.75,
+      "longitude": -117.2
+    }
+  },
+  "92139": {
+    "coordinates": {
+      "latitude": 32.6858257,
+      "longitude": -117.0382158
+    }
+  },
+  "92140": {
+    "coordinates": {
+      "latitude": 32.7407191,
+      "longitude": -117.2036713
+    }
+  },
+  "92142": {
+    "coordinates": {
+      "latitude": 32.84,
+      "longitude": -117.1
+    }
+  },
+  "92143": {
+    "coordinates": {
+      "latitude": 32.55,
+      "longitude": -117.04
+    }
+  },
+  "92145": {
+    "coordinates": {
+      "latitude": 32.8728949,
+      "longitude": -117.1323579
+    }
+  },
+  "92147": {
+    "coordinates": {
+      "latitude": 32.7255292,
+      "longitude": -117.218372
+    }
+  },
+  "92149": {
+    "coordinates": {
+      "latitude": 32.6758544,
+      "longitude": -117.064977
+    }
+  },
+  "92150": {
+    "coordinates": {
+      "latitude": 32.9799999,
+      "longitude": -117.08
+    }
+  },
+  "92152": {
+    "coordinates": {
+      "latitude": 32.7082449,
+      "longitude": -117.2492384
+    }
+  },
+  "92153": {
+    "coordinates": {
+      "latitude": 32.5746598,
+      "longitude": -117.0697958
+    }
+  },
+  "92154": {
+    "coordinates": {
+      "latitude": 32.5967198,
+      "longitude": -116.9028125
+    }
+  },
+  "92155": {
+    "coordinates": {
+      "latitude": 32.6771442,
+      "longitude": -117.15846
+    }
+  },
+  "92158": {
+    "coordinates": {
+      "latitude": 32.5737841,
+      "longitude": -116.9191775
+    }
+  },
+  "92159": {
+    "coordinates": {
+      "latitude": 32.8,
+      "longitude": -117.01
+    }
+  },
+  "92160": {
+    "coordinates": {
+      "latitude": 32.7825872,
+      "longitude": -117.0919659
+    }
+  },
+  "92161": {
+    "coordinates": {
+      "latitude": 32.8758428,
+      "longitude": -117.2367464
+    }
+  },
+  "92162": {
+    "coordinates": {
+      "latitude": 33.016928,
+      "longitude": -116.846046
+    }
+  },
+  "92163": {
+    "coordinates": {
+      "latitude": 32.7495327,
+      "longitude": -117.1509999
+    }
+  },
+  "92164": {
+    "coordinates": {
+      "latitude": 33.016928,
+      "longitude": -116.846046
+    }
+  },
+  "92165": {
+    "coordinates": {
+      "latitude": 32.7495898,
+      "longitude": -117.1046198
+    }
+  },
+  "92166": {
+    "coordinates": {
+      "latitude": 32.7210136,
+      "longitude": -117.2311768
+    }
+  },
+  "92167": {
+    "coordinates": {
+      "latitude": 32.7459028,
+      "longitude": -117.2474632
+    }
+  },
+  "92168": {
+    "coordinates": {
+      "latitude": 32.7830113,
+      "longitude": -117.1707951
+    }
+  },
+  "92169": {
+    "coordinates": {
+      "latitude": 32.7990641,
+      "longitude": -117.2524218
+    }
+  },
+  "92170": {
+    "coordinates": {
+      "latitude": 32.6969212,
+      "longitude": -117.1343318
+    }
+  },
+  "92171": {
+    "coordinates": {
+      "latitude": 32.78,
+      "longitude": -117.17
+    }
+  },
+  "92172": {
+    "coordinates": {
+      "latitude": 32.9571955,
+      "longitude": -117.1274434
+    }
+  },
+  "92173": {
+    "coordinates": {
+      "latitude": 32.5497444,
+      "longitude": -117.0382158
+    }
+  },
+  "92174": {
+    "coordinates": {
+      "latitude": 32.71,
+      "longitude": -117.08
+    }
+  },
+  "92175": {
+    "coordinates": {
+      "latitude": 32.7649983,
+      "longitude": -117.0606249
+    }
+  },
+  "92176": {
+    "coordinates": {
+      "latitude": 32.7634169,
+      "longitude": -117.1230937
+    }
+  },
+  "92177": {
+    "coordinates": {
+      "latitude": 32.8241765,
+      "longitude": -117.2315546
+    }
+  },
+  "92178": {
+    "coordinates": {
+      "latitude": 32.6840044,
+      "longitude": -117.1779216
+    }
+  },
+  "92179": {
+    "coordinates": {
+      "latitude": 32.574219,
+      "longitude": -116.9322553
+    }
+  },
+  "92182": {
+    "coordinates": {
+      "latitude": 32.7759882,
+      "longitude": -117.072053
+    }
+  },
+  "92184": {
+    "coordinates": {
+      "latitude": 33.016928,
+      "longitude": -116.846046
+    }
+  },
+  "92186": {
+    "coordinates": {
+      "latitude": 32.75,
+      "longitude": -117.2
+    }
+  },
+  "92187": {
+    "coordinates": {
+      "latitude": 32.7179256,
+      "longitude": -117.1628713
+    }
+  },
+  "92190": {
+    "coordinates": {
+      "latitude": 33.016928,
+      "longitude": -116.846046
+    }
+  },
+  "92191": {
+    "coordinates": {
+      "latitude": 32.903454,
+      "longitude": -117.2195678
+    }
+  },
+  "92192": {
+    "coordinates": {
+      "latitude": 32.8511526,
+      "longitude": -117.2152819
+    }
+  },
+  "92193": {
+    "coordinates": {
+      "latitude": 32.8015902,
+      "longitude": -117.1400471
+    }
+  },
+  "92194": {
+    "coordinates": {
+      "latitude": 33.016928,
+      "longitude": -116.846046
+    }
+  },
+  "92195": {
+    "coordinates": {
+      "latitude": 32.7649983,
+      "longitude": -117.0606249
+    }
+  },
+  "92196": {
+    "coordinates": {
+      "latitude": 32.92,
+      "longitude": -117.13
+    }
+  },
+  "92197": {
+    "coordinates": {
+      "latitude": 32.9817038,
+      "longitude": -117.0830341
+    }
+  },
+  "92198": {
+    "coordinates": {
+      "latitude": 33.0219718,
+      "longitude": -117.0744922
+    }
+  },
+  "92199": {
+    "coordinates": {
+      "latitude": 32.9816286,
+      "longitude": -117.0830267
+    }
+  },
+  "92201": {
+    "coordinates": {
+      "latitude": 33.7140561,
+      "longitude": -116.2186488
+    }
+  },
+  "92202": {
+    "coordinates": {
+      "latitude": 33.7158335,
+      "longitude": -116.2172641
+    }
+  },
+  "92203": {
+    "coordinates": {
+      "latitude": 33.745603,
+      "longitude": -116.1713917
+    }
+  },
+  "92210": {
+    "coordinates": {
+      "latitude": 33.6871383,
+      "longitude": -116.3367515
+    }
+  },
+  "92211": {
+    "coordinates": {
+      "latitude": 33.7637689,
+      "longitude": -116.3426552
+    }
+  },
+  "92220": {
+    "coordinates": {
+      "latitude": 33.9273122,
+      "longitude": -116.8674757
+    }
+  },
+  "92222": {
+    "coordinates": {
+      "latitude": 32.7854318,
+      "longitude": -114.5628711
+    }
+  },
+  "92223": {
+    "coordinates": {
+      "latitude": 33.9334088,
+      "longitude": -116.9734685
+    }
+  },
+  "92225": {
+    "coordinates": {
+      "latitude": 33.7310815,
+      "longitude": -114.6667939
+    }
+  },
+  "92226": {
+    "coordinates": {
+      "latitude": 33.61,
+      "longitude": -114.6
+    }
+  },
+  "92227": {
+    "coordinates": {
+      "latitude": 33.00010779999999,
+      "longitude": -115.3311689
+    }
+  },
+  "92230": {
+    "coordinates": {
+      "latitude": 33.9155838,
+      "longitude": -116.7850009
+    }
+  },
+  "92231": {
+    "coordinates": {
+      "latitude": 32.6826471,
+      "longitude": -115.5799503
+    }
+  },
+  "92232": {
+    "coordinates": {
+      "latitude": 32.6791203,
+      "longitude": -115.5024549
+    }
+  },
+  "92233": {
+    "coordinates": {
+      "latitude": 33.1904717,
+      "longitude": -115.6154732
+    }
+  },
+  "92234": {
+    "coordinates": {
+      "latitude": 33.82632359999999,
+      "longitude": -116.4547962
+    }
+  },
+  "92235": {
+    "coordinates": {
+      "latitude": 33.8083362,
+      "longitude": -116.4579818
+    }
+  },
+  "92236": {
+    "coordinates": {
+      "latitude": 33.6885095,
+      "longitude": -116.1477598
+    }
+  },
+  "92239": {
+    "coordinates": {
+      "latitude": 33.7504624,
+      "longitude": -115.4496624
+    }
+  },
+  "92240": {
+    "coordinates": {
+      "latitude": 33.9628146,
+      "longitude": -116.5373923
+    }
+  },
+  "92241": {
+    "coordinates": {
+      "latitude": 33.861935,
+      "longitude": -116.2540856
+    }
+  },
+  "92242": {
+    "coordinates": {
+      "latitude": 34.1705136,
+      "longitude": -114.3222577
+    }
+  },
+  "92243": {
+    "coordinates": {
+      "latitude": 32.7538822,
+      "longitude": -115.5917918
+    }
+  },
+  "92244": {
+    "coordinates": {
+      "latitude": 32.7928908,
+      "longitude": -115.5726191
+    }
+  },
+  "92249": {
+    "coordinates": {
+      "latitude": 32.7283132,
+      "longitude": -115.491124
+    }
+  },
+  "92250": {
+    "coordinates": {
+      "latitude": 32.7674331,
+      "longitude": -115.2363408
+    }
+  },
+  "92251": {
+    "coordinates": {
+      "latitude": 32.8491869,
+      "longitude": -115.7338502
+    }
+  },
+  "92252": {
+    "coordinates": {
+      "latitude": 34.193766,
+      "longitude": -116.2540856
+    }
+  },
+  "92253": {
+    "coordinates": {
+      "latitude": 33.6562975,
+      "longitude": -116.2895173
+    }
+  },
+  "92254": {
+    "coordinates": {
+      "latitude": 33.5381708,
+      "longitude": -115.9822747
+    }
+  },
+  "92255": {
+    "coordinates": {
+      "latitude": 33.72,
+      "longitude": -116.37
+    }
+  },
+  "92256": {
+    "coordinates": {
+      "latitude": 34.0761084,
+      "longitude": -116.5845767
+    }
+  },
+  "92257": {
+    "coordinates": {
+      "latitude": 33.3365588,
+      "longitude": -115.3311689
+    }
+  },
+  "92258": {
+    "coordinates": {
+      "latitude": 33.923751,
+      "longitude": -116.5410789
+    }
+  },
+  "92259": {
+    "coordinates": {
+      "latitude": 32.6865306,
+      "longitude": -115.9940986
+    }
+  },
+  "92260": {
+    "coordinates": {
+      "latitude": 33.6917281,
+      "longitude": -116.4075854
+    }
+  },
+  "92261": {
+    "coordinates": {
+      "latitude": 33.7470537,
+      "longitude": -116.358752
+    }
+  },
+  "92262": {
+    "coordinates": {
+      "latitude": 33.8613433,
+      "longitude": -116.5727815
+    }
+  },
+  "92263": {
+    "coordinates": {
+      "latitude": 33.8259597,
+      "longitude": -116.5440081
+    }
+  },
+  "92264": {
+    "coordinates": {
+      "latitude": 33.7553867,
+      "longitude": -116.5373923
+    }
+  },
+  "92266": {
+    "coordinates": {
+      "latitude": 33.3342668,
+      "longitude": -114.9516869
+    }
+  },
+  "92267": {
+    "coordinates": {
+      "latitude": 34.2840795,
+      "longitude": -114.1796057
+    }
+  },
+  "92268": {
+    "coordinates": {
+      "latitude": 34.241485,
+      "longitude": -116.5845767
+    }
+  },
+  "92270": {
+    "coordinates": {
+      "latitude": 33.7694489,
+      "longitude": -116.431192
+    }
+  },
+  "92271": {
+    "coordinates": {
+      "latitude": 33.53163,
+      "longitude": -114.892368
+    }
+  },
+  "92273": {
+    "coordinates": {
+      "latitude": 32.7908378,
+      "longitude": -115.6939036
+    }
+  },
+  "92274": {
+    "coordinates": {
+      "latitude": 33.5658807,
+      "longitude": -116.1832068
+    }
+  },
+  "92275": {
+    "coordinates": {
+      "latitude": 33.248298,
+      "longitude": -115.8285153
+    }
+  },
+  "92276": {
+    "coordinates": {
+      "latitude": 33.8326524,
+      "longitude": -116.3367515
+    }
+  },
+  "92277": {
+    "coordinates": {
+      "latitude": 34.1356099,
+      "longitude": -116.0542941
+    }
+  },
+  "92278": {
+    "coordinates": {
+      "latitude": 34.2327172,
+      "longitude": -116.0560817
+    }
+  },
+  "92280": {
+    "coordinates": {
+      "latitude": 34.1441302,
+      "longitude": -114.5955356
+    }
+  },
+  "92281": {
+    "coordinates": {
+      "latitude": 33.0656784,
+      "longitude": -115.5858711
+    }
+  },
+  "92282": {
+    "coordinates": {
+      "latitude": 33.9561684,
+      "longitude": -116.6553351
+    }
+  },
+  "92283": {
+    "coordinates": {
+      "latitude": 32.9005186,
+      "longitude": -114.8092691
+    }
+  },
+  "92284": {
+    "coordinates": {
+      "latitude": 34.1502862,
+      "longitude": -116.4429944
+    }
+  },
+  "92285": {
+    "coordinates": {
+      "latitude": 34.3350492,
+      "longitude": -116.5373923
+    }
+  },
+  "92286": {
+    "coordinates": {
+      "latitude": 34.1206177,
+      "longitude": -116.4141447
+    }
+  },
+  "92292": {
+    "coordinates": {
+      "latitude": 33.752886,
+      "longitude": -116.055617
+    }
+  },
+  "92301": {
+    "coordinates": {
+      "latitude": 34.6599838,
+      "longitude": -117.5026174
+    }
+  },
+  "92304": {
+    "coordinates": {
+      "latitude": 34.5430873,
+      "longitude": -115.5799503
+    }
+  },
+  "92305": {
+    "coordinates": {
+      "latitude": 34.1752565,
+      "longitude": -116.8674757
+    }
+  },
+  "92307": {
+    "coordinates": {
+      "latitude": 34.5869607,
+      "longitude": -117.1264753
+    }
+  },
+  "92308": {
+    "coordinates": {
+      "latitude": 34.3965399,
+      "longitude": -117.1500048
+    }
+  },
+  "92309": {
+    "coordinates": {
+      "latitude": 35.0926761,
+      "longitude": -116.2422739
+    }
+  },
+  "92310": {
+    "coordinates": {
+      "latitude": 35.2682707,
+      "longitude": -116.7142835
+    }
+  },
+  "92311": {
+    "coordinates": {
+      "latitude": 34.9744981,
+      "longitude": -116.9616941
+    }
+  },
+  "92312": {
+    "coordinates": {
+      "latitude": 34.8952028,
+      "longitude": -117.0261359
+    }
+  },
+  "92313": {
+    "coordinates": {
+      "latitude": 34.03437750000001,
+      "longitude": -117.3087578
+    }
+  },
+  "92314": {
+    "coordinates": {
+      "latitude": 34.2296046,
+      "longitude": -116.8556955
+    }
+  },
+  "92315": {
+    "coordinates": {
+      "latitude": 34.2428813,
+      "longitude": -116.9087014
+    }
+  },
+  "92316": {
+    "coordinates": {
+      "latitude": 34.0595859,
+      "longitude": -117.3968996
+    }
+  },
+  "92317": {
+    "coordinates": {
+      "latitude": 34.2383916,
+      "longitude": -117.2181252
+    }
+  },
+  "92318": {
+    "coordinates": {
+      "latitude": 34.0472706,
+      "longitude": -117.2386415
+    }
+  },
+  "92320": {
+    "coordinates": {
+      "latitude": 33.9900379,
+      "longitude": -117.0617553
+    }
+  },
+  "92321": {
+    "coordinates": {
+      "latitude": 34.2563043,
+      "longitude": -117.1558867
+    }
+  },
+  "92322": {
+    "coordinates": {
+      "latitude": 34.2500685,
+      "longitude": -117.3257366
+    }
+  },
+  "92323": {
+    "coordinates": {
+      "latitude": 35.2376778,
+      "longitude": -115.4993118
+    }
+  },
+  "92324": {
+    "coordinates": {
+      "latitude": 34.0559145,
+      "longitude": -117.3263893
+    }
+  },
+  "92325": {
+    "coordinates": {
+      "latitude": 34.2524771,
+      "longitude": -117.2793685
+    }
+  },
+  "92326": {
+    "coordinates": {
+      "latitude": 34.839964,
+      "longitude": -115.967051
+    }
+  },
+  "92327": {
+    "coordinates": {
+      "latitude": 34.8667466,
+      "longitude": -116.8556955
+    }
+  },
+  "92328": {
+    "coordinates": {
+      "latitude": 36.5512675,
+      "longitude": -116.8910342
+    }
+  },
+  "92329": {
+    "coordinates": {
+      "latitude": 34.43,
+      "longitude": -117.57
+    }
+  },
+  "92332": {
+    "coordinates": {
+      "latitude": 34.9399855,
+      "longitude": -115.2363408
+    }
+  },
+  "92333": {
+    "coordinates": {
+      "latitude": 34.2636333,
+      "longitude": -116.9734685
+    }
+  },
+  "92334": {
+    "coordinates": {
+      "latitude": 34.103261,
+      "longitude": -117.4358563
+    }
+  },
+  "92335": {
+    "coordinates": {
+      "latitude": 34.08378700000001,
+      "longitude": -117.4673845
+    }
+  },
+  "92336": {
+    "coordinates": {
+      "latitude": 34.145515,
+      "longitude": -117.4673845
+    }
+  },
+  "92337": {
+    "coordinates": {
+      "latitude": 34.0482749,
+      "longitude": -117.4438924
+    }
+  },
+  "92338": {
+    "coordinates": {
+      "latitude": 34.8085641,
+      "longitude": -116.1832068
+    }
+  },
+  "92339": {
+    "coordinates": {
+      "latitude": 34.0946892,
+      "longitude": -116.9028125
+    }
+  },
+  "92340": {
+    "coordinates": {
+      "latitude": 34.4159792,
+      "longitude": -117.2880311
+    }
+  },
+  "92341": {
+    "coordinates": {
+      "latitude": 34.2412908,
+      "longitude": -117.0676398
+    }
+  },
+  "92342": {
+    "coordinates": {
+      "latitude": 34.7612737,
+      "longitude": -117.3381427
+    }
+  },
+  "92345": {
+    "coordinates": {
+      "latitude": 34.3627106,
+      "longitude": -117.2911248
+    }
+  },
+  "92346": {
+    "coordinates": {
+      "latitude": 34.1286356,
+      "longitude": -117.2089374
+    }
+  },
+  "92347": {
+    "coordinates": {
+      "latitude": 34.973582,
+      "longitude": -117.2205771
+    }
+  },
+  "92350": {
+    "coordinates": {
+      "latitude": 34.0501932,
+      "longitude": -117.264176
+    }
+  },
+  "92352": {
+    "coordinates": {
+      "latitude": 34.2693794,
+      "longitude": -117.2088167
+    }
+  },
+  "92354": {
+    "coordinates": {
+      "latitude": 34.0484387,
+      "longitude": -117.2499749
+    }
+  },
+  "92356": {
+    "coordinates": {
+      "latitude": 34.4375566,
+      "longitude": -116.8910342
+    }
+  },
+  "92357": {
+    "coordinates": {
+      "latitude": 34.0510542,
+      "longitude": -117.252326
+    }
+  },
+  "92358": {
+    "coordinates": {
+      "latitude": 34.2238173,
+      "longitude": -117.5261025
+    }
+  },
+  "92359": {
+    "coordinates": {
+      "latitude": 34.097004,
+      "longitude": -117.0676398
+    }
+  },
+  "92363": {
+    "coordinates": {
+      "latitude": 34.7275112,
+      "longitude": -114.5955356
+    }
+  },
+  "92364": {
+    "coordinates": {
+      "latitude": 35.3490313,
+      "longitude": -115.6154732
+    }
+  },
+  "92365": {
+    "coordinates": {
+      "latitude": 34.8628939,
+      "longitude": -116.6553351
+    }
+  },
+  "92366": {
+    "coordinates": {
+      "latitude": 35.47,
+      "longitude": -115.54
+    }
+  },
+  "92368": {
+    "coordinates": {
+      "latitude": 34.6498616,
+      "longitude": -117.2911248
+    }
+  },
+  "92369": {
+    "coordinates": {
+      "latitude": 34.1357915,
+      "longitude": -117.2309512
+    }
+  },
+  "92371": {
+    "coordinates": {
+      "latitude": 34.4290417,
+      "longitude": -117.5261025
+    }
+  },
+  "92372": {
+    "coordinates": {
+      "latitude": 34.4340464,
+      "longitude": -117.6317494
+    }
+  },
+  "92373": {
+    "coordinates": {
+      "latitude": 34.0127473,
+      "longitude": -117.1617685
+    }
+  },
+  "92374": {
+    "coordinates": {
+      "latitude": 34.0708773,
+      "longitude": -117.1558867
+    }
+  },
+  "92375": {
+    "coordinates": {
+      "latitude": 34.0554025,
+      "longitude": -117.1854935
+    }
+  },
+  "92376": {
+    "coordinates": {
+      "latitude": 34.1063841,
+      "longitude": -117.3703189
+    }
+  },
+  "92377": {
+    "coordinates": {
+      "latitude": 34.1559542,
+      "longitude": -117.4027743
+    }
+  },
+  "92378": {
+    "coordinates": {
+      "latitude": 34.2319627,
+      "longitude": -117.214697
+    }
+  },
+  "92382": {
+    "coordinates": {
+      "latitude": 34.2244855,
+      "longitude": -117.1382404
+    }
+  },
+  "92384": {
+    "coordinates": {
+      "latitude": 36.01936190000001,
+      "longitude": -116.1595761
+    }
+  },
+  "92385": {
+    "coordinates": {
+      "latitude": 34.2353739,
+      "longitude": -117.1794216
+    }
+  },
+  "92386": {
+    "coordinates": {
+      "latitude": 34.2426357,
+      "longitude": -116.827715
+    }
+  },
+  "92389": {
+    "coordinates": {
+      "latitude": 35.8975746,
+      "longitude": -116.1595761
+    }
+  },
+  "92391": {
+    "coordinates": {
+      "latitude": 34.2398999,
+      "longitude": -117.2352765
+    }
+  },
+  "92392": {
+    "coordinates": {
+      "latitude": 34.4854334,
+      "longitude": -117.4203974
+    }
+  },
+  "92393": {
+    "coordinates": {
+      "latitude": 34.51403,
+      "longitude": -117.36324
+    }
+  },
+  "92394": {
+    "coordinates": {
+      "latitude": 34.5639731,
+      "longitude": -117.3498955
+    }
+  },
+  "92396": {
+    "coordinates": {
+      "latitude": 33.714421,
+      "longitude": -117.069361
+    }
+  },
+  "92397": {
+    "coordinates": {
+      "latitude": 34.3668408,
+      "longitude": -117.6552185
+    }
+  },
+  "92398": {
+    "coordinates": {
+      "latitude": 34.918849,
+      "longitude": -116.8733656
+    }
+  },
+  "92399": {
+    "coordinates": {
+      "latitude": 34.0593543,
+      "longitude": -117.0087877
+    }
+  },
+  "92401": {
+    "coordinates": {
+      "latitude": 34.0971415,
+      "longitude": -117.2940637
+    }
+  },
+  "92402": {
+    "coordinates": {
+      "latitude": 34.27876810000001,
+      "longitude": -117.1504967
+    }
+  },
+  "92403": {
+    "coordinates": {
+      "latitude": 34.0633987,
+      "longitude": -117.285063
+    }
+  },
+  "92404": {
+    "coordinates": {
+      "latitude": 34.1585191,
+      "longitude": -117.2554498
+    }
+  },
+  "92405": {
+    "coordinates": {
+      "latitude": 34.1402037,
+      "longitude": -117.2970026
+    }
+  },
+  "92406": {
+    "coordinates": {
+      "latitude": 34.14,
+      "longitude": -117.29
+    }
+  },
+  "92407": {
+    "coordinates": {
+      "latitude": 34.216765,
+      "longitude": -117.3851496
+    }
+  },
+  "92408": {
+    "coordinates": {
+      "latitude": 34.0868517,
+      "longitude": -117.2617329
+    }
+  },
+  "92410": {
+    "coordinates": {
+      "latitude": 34.0961955,
+      "longitude": -117.3087578
+    }
+  },
+  "92411": {
+    "coordinates": {
+      "latitude": 34.1242701,
+      "longitude": -117.3205123
+    }
+  },
+  "92412": {
+    "coordinates": {
+      "latitude": 34.839964,
+      "longitude": -115.967051
+    }
+  },
+  "92413": {
+    "coordinates": {
+      "latitude": 34.1412455,
+      "longitude": -117.2523025
+    }
+  },
+  "92414": {
+    "coordinates": {
+      "latitude": 34.839964,
+      "longitude": -115.967051
+    }
+  },
+  "92415": {
+    "coordinates": {
+      "latitude": 34.1301599,
+      "longitude": -117.2690813
+    }
+  },
+  "92416": {
+    "coordinates": {
+      "latitude": 34.839964,
+      "longitude": -115.967051
+    }
+  },
+  "92418": {
+    "coordinates": {
+      "latitude": 34.1043988,
+      "longitude": -117.293329
+    }
+  },
+  "92420": {
+    "coordinates": {
+      "latitude": 34.839964,
+      "longitude": -115.967051
+    }
+  },
+  "92423": {
+    "coordinates": {
+      "latitude": 34.11,
+      "longitude": -117.29
+    }
+  },
+  "92424": {
+    "coordinates": {
+      "latitude": 34.839964,
+      "longitude": -115.967051
+    }
+  },
+  "92427": {
+    "coordinates": {
+      "latitude": 34.1701882,
+      "longitude": -117.341017
+    }
+  },
+  "92501": {
+    "coordinates": {
+      "latitude": 33.999677,
+      "longitude": -117.3675233
+    }
+  },
+  "92502": {
+    "coordinates": {
+      "latitude": 33.9799999,
+      "longitude": -117.37
+    }
+  },
+  "92503": {
+    "coordinates": {
+      "latitude": 33.8833867,
+      "longitude": -117.4438924
+    }
+  },
+  "92504": {
+    "coordinates": {
+      "latitude": 33.9012386,
+      "longitude": -117.3910247
+    }
+  },
+  "92505": {
+    "coordinates": {
+      "latitude": 33.913326,
+      "longitude": -117.4908738
+    }
+  },
+  "92506": {
+    "coordinates": {
+      "latitude": 33.9415653,
+      "longitude": -117.3733989
+    }
+  },
+  "92507": {
+    "coordinates": {
+      "latitude": 33.9734553,
+      "longitude": -117.3263893
+    }
+  },
+  "92508": {
+    "coordinates": {
+      "latitude": 33.890925,
+      "longitude": -117.3263893
+    }
+  },
+  "92509": {
+    "coordinates": {
+      "latitude": 33.9996052,
+      "longitude": -117.4321452
+    }
+  },
+  "92513": {
+    "coordinates": {
+      "latitude": 33.9150851,
+      "longitude": -117.4630309
+    }
+  },
+  "92514": {
+    "coordinates": {
+      "latitude": 33.9460234,
+      "longitude": -117.4163108
+    }
+  },
+  "92515": {
+    "coordinates": {
+      "latitude": 33.752886,
+      "longitude": -116.055617
+    }
+  },
+  "92516": {
+    "coordinates": {
+      "latitude": 33.9546403,
+      "longitude": -117.3936282
+    }
+  },
+  "92517": {
+    "coordinates": {
+      "latitude": 33.9724007,
+      "longitude": -117.3484317
+    }
+  },
+  "92518": {
+    "coordinates": {
+      "latitude": 33.888079,
+      "longitude": -117.2734901
+    }
+  },
+  "92519": {
+    "coordinates": {
+      "latitude": 33.9953859,
+      "longitude": -117.4130737
+    }
+  },
+  "92521": {
+    "coordinates": {
+      "latitude": 33.9756518,
+      "longitude": -117.3311106
+    }
+  },
+  "92522": {
+    "coordinates": {
+      "latitude": 33.9811363,
+      "longitude": -117.374317
+    }
+  },
+  "92530": {
+    "coordinates": {
+      "latitude": 33.6392361,
+      "longitude": -117.3851496
+    }
+  },
+  "92531": {
+    "coordinates": {
+      "latitude": 33.6693998,
+      "longitude": -117.3326689
+    }
+  },
+  "92532": {
+    "coordinates": {
+      "latitude": 33.663476,
+      "longitude": -117.2617329
+    }
+  },
+  "92536": {
+    "coordinates": {
+      "latitude": 33.4820617,
+      "longitude": -116.8203511
+    }
+  },
+  "92539": {
+    "coordinates": {
+      "latitude": 33.5257713,
+      "longitude": -116.6317514
+    }
+  },
+  "92543": {
+    "coordinates": {
+      "latitude": 33.6991526,
+      "longitude": -116.9793554
+    }
+  },
+  "92544": {
+    "coordinates": {
+      "latitude": 33.6634859,
+      "longitude": -116.8439147
+    }
+  },
+  "92545": {
+    "coordinates": {
+      "latitude": 33.736074,
+      "longitude": -117.0205594
+    }
+  },
+  "92546": {
+    "coordinates": {
+      "latitude": 33.7434556,
+      "longitude": -116.9715536
+    }
+  },
+  "92548": {
+    "coordinates": {
+      "latitude": 33.7552579,
+      "longitude": -117.1147095
+    }
+  },
+  "92549": {
+    "coordinates": {
+      "latitude": 33.7608141,
+      "longitude": -116.7378585
+    }
+  },
+  "92551": {
+    "coordinates": {
+      "latitude": 33.878638,
+      "longitude": -117.226457
+    }
+  },
+  "92552": {
+    "coordinates": {
+      "latitude": 33.9173225,
+      "longitude": -117.2508566
+    }
+  },
+  "92553": {
+    "coordinates": {
+      "latitude": 33.924658,
+      "longitude": -117.2499749
+    }
+  },
+  "92554": {
+    "coordinates": {
+      "latitude": 33.92,
+      "longitude": -117.16
+    }
+  },
+  "92555": {
+    "coordinates": {
+      "latitude": 33.9206847,
+      "longitude": -117.1147095
+    }
+  },
+  "92556": {
+    "coordinates": {
+      "latitude": 33.92,
+      "longitude": -117.16
+    }
+  },
+  "92557": {
+    "coordinates": {
+      "latitude": 33.9696912,
+      "longitude": -117.255854
+    }
+  },
+  "92561": {
+    "coordinates": {
+      "latitude": 33.630717,
+      "longitude": -116.5373923
+    }
+  },
+  "92562": {
+    "coordinates": {
+      "latitude": 33.5262326,
+      "longitude": -117.3381427
+    }
+  },
+  "92563": {
+    "coordinates": {
+      "latitude": 33.5784347,
+      "longitude": -117.1617685
+    }
+  },
+  "92564": {
+    "coordinates": {
+      "latitude": 33.5745494,
+      "longitude": -117.1779802
+    }
+  },
+  "92567": {
+    "coordinates": {
+      "latitude": 33.8173261,
+      "longitude": -117.1147095
+    }
+  },
+  "92570": {
+    "coordinates": {
+      "latitude": 33.7857455,
+      "longitude": -117.2911248
+    }
+  },
+  "92571": {
+    "coordinates": {
+      "latitude": 33.81567709999999,
+      "longitude": -117.2088167
+    }
+  },
+  "92572": {
+    "coordinates": {
+      "latitude": 33.7794367,
+      "longitude": -117.2174059
+    }
+  },
+  "92581": {
+    "coordinates": {
+      "latitude": 33.7729474,
+      "longitude": -116.9618653
+    }
+  },
+  "92582": {
+    "coordinates": {
+      "latitude": 33.7981884,
+      "longitude": -117.0205594
+    }
+  },
+  "92583": {
+    "coordinates": {
+      "latitude": 33.814818,
+      "longitude": -116.9499191
+    }
+  },
+  "92584": {
+    "coordinates": {
+      "latitude": 33.6557387,
+      "longitude": -117.185294
+    }
+  },
+  "92585": {
+    "coordinates": {
+      "latitude": 33.7441155,
+      "longitude": -117.1617685
+    }
+  },
+  "92586": {
+    "coordinates": {
+      "latitude": 33.7084855,
+      "longitude": -117.2029363
+    }
+  },
+  "92587": {
+    "coordinates": {
+      "latitude": 33.7010881,
+      "longitude": -117.255854
+    }
+  },
+  "92589": {
+    "coordinates": {
+      "latitude": 33.49,
+      "longitude": -117.15
+    }
+  },
+  "92590": {
+    "coordinates": {
+      "latitude": 33.4767802,
+      "longitude": -117.1970557
+    }
+  },
+  "92591": {
+    "coordinates": {
+      "latitude": 33.5273381,
+      "longitude": -117.1147095
+    }
+  },
+  "92592": {
+    "coordinates": {
+      "latitude": 33.43806010000001,
+      "longitude": -117.0087877
+    }
+  },
+  "92593": {
+    "coordinates": {
+      "latitude": 33.5075041,
+      "longitude": -117.1217421
+    }
+  },
+  "92595": {
+    "coordinates": {
+      "latitude": 33.61829210000001,
+      "longitude": -117.255854
+    }
+  },
+  "92596": {
+    "coordinates": {
+      "latitude": 33.6345169,
+      "longitude": -117.0558707
+    }
+  },
+  "92599": {
+    "coordinates": {
+      "latitude": 33.8386728,
+      "longitude": -117.2393709
+    }
+  },
+  "92602": {
+    "coordinates": {
+      "latitude": 33.7514861,
+      "longitude": -117.7549295
+    }
+  },
+  "92603": {
+    "coordinates": {
+      "latitude": 33.6332102,
+      "longitude": -117.7959713
+    }
+  },
+  "92604": {
+    "coordinates": {
+      "latitude": 33.6913751,
+      "longitude": -117.7901088
+    }
+  },
+  "92605": {
+    "coordinates": {
+      "latitude": 33.7337599,
+      "longitude": -117.99995
+    }
+  },
+  "92606": {
+    "coordinates": {
+      "latitude": 33.6912614,
+      "longitude": -117.8223506
+    }
+  },
+  "92607": {
+    "coordinates": {
+      "latitude": 33.52603,
+      "longitude": -117.71093
+    }
+  },
+  "92610": {
+    "coordinates": {
+      "latitude": 33.6917217,
+      "longitude": -117.6610854
+    }
+  },
+  "92612": {
+    "coordinates": {
+      "latitude": 33.6588951,
+      "longitude": -117.8282121
+    }
+  },
+  "92614": {
+    "coordinates": {
+      "latitude": 33.6832497,
+      "longitude": -117.8340735
+    }
+  },
+  "92615": {
+    "coordinates": {
+      "latitude": 33.6578033,
+      "longitude": -117.9693144
+    }
+  },
+  "92616": {
+    "coordinates": {
+      "latitude": 33.6477498,
+      "longitude": -117.8346428
+    }
+  },
+  "92618": {
+    "coordinates": {
+      "latitude": 33.665242,
+      "longitude": -117.7490656
+    }
+  },
+  "92619": {
+    "coordinates": {
+      "latitude": 33.66824210000001,
+      "longitude": -117.7659237
+    }
+  },
+  "92620": {
+    "coordinates": {
+      "latitude": 33.7073908,
+      "longitude": -117.7666567
+    }
+  },
+  "92623": {
+    "coordinates": {
+      "latitude": 33.684587,
+      "longitude": -117.83188
+    }
+  },
+  "92624": {
+    "coordinates": {
+      "latitude": 33.4559258,
+      "longitude": -117.6640187
+    }
+  },
+  "92625": {
+    "coordinates": {
+      "latitude": 33.599184,
+      "longitude": -117.8721676
+    }
+  },
+  "92626": {
+    "coordinates": {
+      "latitude": 33.6834142,
+      "longitude": -117.9073244
+    }
+  },
+  "92627": {
+    "coordinates": {
+      "latitude": 33.6496252,
+      "longitude": -117.9190418
+    }
+  },
+  "92628": {
+    "coordinates": {
+      "latitude": 33.673202,
+      "longitude": -117.9233294
+    }
+  },
+  "92629": {
+    "coordinates": {
+      "latitude": 33.4699974,
+      "longitude": -117.702148
+    }
+  },
+  "92630": {
+    "coordinates": {
+      "latitude": 33.6447519,
+      "longitude": -117.6845508
+    }
+  },
+  "92635": {
+    "coordinates": {
+      "latitude": 33.573176,
+      "longitude": -117.698173
+    }
+  },
+  "92646": {
+    "coordinates": {
+      "latitude": 33.6587745,
+      "longitude": -117.9659037
+    }
+  },
+  "92647": {
+    "coordinates": {
+      "latitude": 33.7222674,
+      "longitude": -118.0010421
+    }
+  },
+  "92648": {
+    "coordinates": {
+      "latitude": 33.6781963,
+      "longitude": -118.0127534
+    }
+  },
+  "92649": {
+    "coordinates": {
+      "latitude": 33.721051,
+      "longitude": -118.0478826
+    }
+  },
+  "92650": {
+    "coordinates": {
+      "latitude": 33.6756136,
+      "longitude": -117.7586938
+    }
+  },
+  "92651": {
+    "coordinates": {
+      "latitude": 33.5563145,
+      "longitude": -117.77252
+    }
+  },
+  "92652": {
+    "coordinates": {
+      "latitude": 33.5441062,
+      "longitude": -117.7820073
+    }
+  },
+  "92653": {
+    "coordinates": {
+      "latitude": 33.590277,
+      "longitude": -117.6962824
+    }
+  },
+  "92654": {
+    "coordinates": {
+      "latitude": 33.6077265,
+      "longitude": -117.7107887
+    }
+  },
+  "92655": {
+    "coordinates": {
+      "latitude": 33.746245,
+      "longitude": -117.9820097
+    }
+  },
+  "92656": {
+    "coordinates": {
+      "latitude": 33.5714289,
+      "longitude": -117.7314729
+    }
+  },
+  "92657": {
+    "coordinates": {
+      "latitude": 33.5974299,
+      "longitude": -117.8370041
+    }
+  },
+  "92658": {
+    "coordinates": {
+      "latitude": 33.63915679999999,
+      "longitude": -117.8647939
+    }
+  },
+  "92659": {
+    "coordinates": {
+      "latitude": 33.62145390000001,
+      "longitude": -117.9236751
+    }
+  },
+  "92660": {
+    "coordinates": {
+      "latitude": 33.6301328,
+      "longitude": -117.8721676
+    }
+  },
+  "92661": {
+    "coordinates": {
+      "latitude": 33.602788,
+      "longitude": -117.9102538
+    }
+  },
+  "92662": {
+    "coordinates": {
+      "latitude": 33.6061462,
+      "longitude": -117.8912117
+    }
+  },
+  "92663": {
+    "coordinates": {
+      "latitude": 33.615828,
+      "longitude": -117.9307584
+    }
+  },
+  "92670": {
+    "coordinates": {
+      "latitude": 33.870714,
+      "longitude": -117.879342
+    }
+  },
+  "92672": {
+    "coordinates": {
+      "latitude": 33.4154744,
+      "longitude": -117.5848025
+    }
+  },
+  "92673": {
+    "coordinates": {
+      "latitude": 33.4662881,
+      "longitude": -117.6317494
+    }
+  },
+  "92674": {
+    "coordinates": {
+      "latitude": 33.4369647,
+      "longitude": -117.6237182
+    }
+  },
+  "92675": {
+    "coordinates": {
+      "latitude": 33.5039207,
+      "longitude": -117.5613246
+    }
+  },
+  "92676": {
+    "coordinates": {
+      "latitude": 33.7480914,
+      "longitude": -117.6200138
+    }
+  },
+  "92677": {
+    "coordinates": {
+      "latitude": 33.5320292,
+      "longitude": -117.702148
+    }
+  },
+  "92678": {
+    "coordinates": {
+      "latitude": 33.65963139999999,
+      "longitude": -117.5880996
+    }
+  },
+  "92679": {
+    "coordinates": {
+      "latitude": 33.5941759,
+      "longitude": -117.5730639
+    }
+  },
+  "92680": {
+    "coordinates": {
+      "latitude": 33.792124,
+      "longitude": -117.993561
+    }
+  },
+  "92683": {
+    "coordinates": {
+      "latitude": 33.7531536,
+      "longitude": -118.0010421
+    }
+  },
+  "92684": {
+    "coordinates": {
+      "latitude": 33.7448375,
+      "longitude": -117.9671748
+    }
+  },
+  "92685": {
+    "coordinates": {
+      "latitude": 33.7438299,
+      "longitude": -118.0019403
+    }
+  },
+  "92688": {
+    "coordinates": {
+      "latitude": 33.63736,
+      "longitude": -117.6082774
+    }
+  },
+  "92690": {
+    "coordinates": {
+      "latitude": 33.5536061,
+      "longitude": -117.67056
+    }
+  },
+  "92691": {
+    "coordinates": {
+      "latitude": 33.6062809,
+      "longitude": -117.6728185
+    }
+  },
+  "92692": {
+    "coordinates": {
+      "latitude": 33.6147846,
+      "longitude": -117.637617
+    }
+  },
+  "92693": {
+    "coordinates": {
+      "latitude": 33.4969633,
+      "longitude": -117.6653321
+    }
+  },
+  "92694": {
+    "coordinates": {
+      "latitude": 33.5507512,
+      "longitude": -117.6411674
+    }
+  },
+  "92697": {
+    "coordinates": {
+      "latitude": 33.6471239,
+      "longitude": -117.8421325
+    }
+  },
+  "92698": {
+    "coordinates": {
+      "latitude": 33.61,
+      "longitude": -117.74
+    }
+  },
+  "92701": {
+    "coordinates": {
+      "latitude": 33.7463915,
+      "longitude": -117.8604472
+    }
+  },
+  "92702": {
+    "coordinates": {
+      "latitude": 33.7490375,
+      "longitude": -117.8657702
+    }
+  },
+  "92703": {
+    "coordinates": {
+      "latitude": 33.7526686,
+      "longitude": -117.9190418
+    }
+  },
+  "92704": {
+    "coordinates": {
+      "latitude": 33.7246333,
+      "longitude": -117.9073244
+    }
+  },
+  "92705": {
+    "coordinates": {
+      "latitude": 33.7532358,
+      "longitude": -117.7901088
+    }
+  },
+  "92706": {
+    "coordinates": {
+      "latitude": 33.7645595,
+      "longitude": -117.8809574
+    }
+  },
+  "92707": {
+    "coordinates": {
+      "latitude": 33.7126158,
+      "longitude": -117.8721676
+    }
+  },
+  "92708": {
+    "coordinates": {
+      "latitude": 33.7168761,
+      "longitude": -117.9600466
+    }
+  },
+  "92709": {
+    "coordinates": {
+      "latitude": 33.640302,
+      "longitude": -117.769442
+    }
+  },
+  "92710": {
+    "coordinates": {
+      "latitude": 33.711552,
+      "longitude": -117.809881
+    }
+  },
+  "92711": {
+    "coordinates": {
+      "latitude": 33.7653884,
+      "longitude": -117.8514524
+    }
+  },
+  "92712": {
+    "coordinates": {
+      "latitude": 33.7515017,
+      "longitude": -117.8716781
+    }
+  },
+  "92728": {
+    "coordinates": {
+      "latitude": 33.7132105,
+      "longitude": -117.9284559
+    }
+  },
+  "92735": {
+    "coordinates": {
+      "latitude": 33.7169034,
+      "longitude": -117.8506504
+    }
+  },
+  "92780": {
+    "coordinates": {
+      "latitude": 33.7372177,
+      "longitude": -117.8135579
+    }
+  },
+  "92781": {
+    "coordinates": {
+      "latitude": 33.7456051,
+      "longitude": -117.8206943
+    }
+  },
+  "92782": {
+    "coordinates": {
+      "latitude": 33.7344836,
+      "longitude": -117.7930401
+    }
+  },
+  "92799": {
+    "coordinates": {
+      "latitude": 33.6967434,
+      "longitude": -117.9120846
+    }
+  },
+  "92801": {
+    "coordinates": {
+      "latitude": 33.8469812,
+      "longitude": -117.9541894
+    }
+  },
+  "92802": {
+    "coordinates": {
+      "latitude": 33.8124094,
+      "longitude": -117.9192679
+    }
+  },
+  "92803": {
+    "coordinates": {
+      "latitude": 33.8416364,
+      "longitude": -117.9373297
+    }
+  },
+  "92804": {
+    "coordinates": {
+      "latitude": 33.82353,
+      "longitude": -117.9659037
+    }
+  },
+  "92805": {
+    "coordinates": {
+      "latitude": 33.8276052,
+      "longitude": -117.9073244
+    }
+  },
+  "92806": {
+    "coordinates": {
+      "latitude": 33.8362104,
+      "longitude": -117.8721676
+    }
+  },
+  "92807": {
+    "coordinates": {
+      "latitude": 33.8459536,
+      "longitude": -117.7901088
+    }
+  },
+  "92808": {
+    "coordinates": {
+      "latitude": 33.8416068,
+      "longitude": -117.702148
+    }
+  },
+  "92811": {
+    "coordinates": {
+      "latitude": 33.8684506,
+      "longitude": -117.8295413
+    }
+  },
+  "92812": {
+    "coordinates": {
+      "latitude": 33.8179838,
+      "longitude": -117.9275434
+    }
+  },
+  "92814": {
+    "coordinates": {
+      "latitude": 33.8177929,
+      "longitude": -117.9615905
+    }
+  },
+  "92815": {
+    "coordinates": {
+      "latitude": 33.8325113,
+      "longitude": -117.9167638
+    }
+  },
+  "92816": {
+    "coordinates": {
+      "latitude": 33.8390385,
+      "longitude": -117.883862
+    }
+  },
+  "92817": {
+    "coordinates": {
+      "latitude": 33.851861,
+      "longitude": -117.7955187
+    }
+  },
+  "92821": {
+    "coordinates": {
+      "latitude": 33.9316733,
+      "longitude": -117.8604472
+    }
+  },
+  "92822": {
+    "coordinates": {
+      "latitude": 33.9176714,
+      "longitude": -117.8903877
+    }
+  },
+  "92823": {
+    "coordinates": {
+      "latitude": 33.9254328,
+      "longitude": -117.8018337
+    }
+  },
+  "92825": {
+    "coordinates": {
+      "latitude": 33.8181422,
+      "longitude": -117.9009893
+    }
+  },
+  "92831": {
+    "coordinates": {
+      "latitude": 33.881922,
+      "longitude": -117.8956062
+    }
+  },
+  "92832": {
+    "coordinates": {
+      "latitude": 33.8733037,
+      "longitude": -117.9307584
+    }
+  },
+  "92833": {
+    "coordinates": {
+      "latitude": 33.8749591,
+      "longitude": -117.9659037
+    }
+  },
+  "92834": {
+    "coordinates": {
+      "latitude": 33.8740731,
+      "longitude": -117.9026351
+    }
+  },
+  "92835": {
+    "coordinates": {
+      "latitude": 33.9041552,
+      "longitude": -117.9307584
+    }
+  },
+  "92836": {
+    "coordinates": {
+      "latitude": 33.8703051,
+      "longitude": -117.9219513
+    }
+  },
+  "92837": {
+    "coordinates": {
+      "latitude": 33.8700351,
+      "longitude": -117.9635047
+    }
+  },
+  "92838": {
+    "coordinates": {
+      "latitude": 33.8917941,
+      "longitude": -117.9304432
+    }
+  },
+  "92840": {
+    "coordinates": {
+      "latitude": 33.7876938,
+      "longitude": -117.9336874
+    }
+  },
+  "92841": {
+    "coordinates": {
+      "latitude": 33.7897841,
+      "longitude": -117.9776173
+    }
+  },
+  "92842": {
+    "coordinates": {
+      "latitude": 33.7777748,
+      "longitude": -117.9507834
+    }
+  },
+  "92843": {
+    "coordinates": {
+      "latitude": 33.7675239,
+      "longitude": -117.9424743
+    }
+  },
+  "92844": {
+    "coordinates": {
+      "latitude": 33.7636344,
+      "longitude": -117.9688322
+    }
+  },
+  "92845": {
+    "coordinates": {
+      "latitude": 33.7852683,
+      "longitude": -118.0273914
+    }
+  },
+  "92846": {
+    "coordinates": {
+      "latitude": 33.7891968,
+      "longitude": -118.0285506
+    }
+  },
+  "92850": {
+    "coordinates": {
+      "latitude": 33.84,
+      "longitude": -117.94
+    }
+  },
+  "92856": {
+    "coordinates": {
+      "latitude": 33.7878196,
+      "longitude": -117.8553713
+    }
+  },
+  "92857": {
+    "coordinates": {
+      "latitude": 33.8331623,
+      "longitude": -117.8472816
+    }
+  },
+  "92859": {
+    "coordinates": {
+      "latitude": 33.7877124,
+      "longitude": -117.8120984
+    }
+  },
+  "92860": {
+    "coordinates": {
+      "latitude": 33.9226096,
+      "longitude": -117.5378439
+    }
+  },
+  "92861": {
+    "coordinates": {
+      "latitude": 33.8177801,
+      "longitude": -117.8106269
+    }
+  },
+  "92862": {
+    "coordinates": {
+      "latitude": 33.81,
+      "longitude": -117.71
+    }
+  },
+  "92863": {
+    "coordinates": {
+      "latitude": 33.8060179,
+      "longitude": -117.8355846
+    }
+  },
+  "92864": {
+    "coordinates": {
+      "latitude": 33.81,
+      "longitude": -117.83
+    }
+  },
+  "92865": {
+    "coordinates": {
+      "latitude": 33.8316472,
+      "longitude": -117.848726
+    }
+  },
+  "92866": {
+    "coordinates": {
+      "latitude": 33.78344939999999,
+      "longitude": -117.8457956
+    }
+  },
+  "92867": {
+    "coordinates": {
+      "latitude": 33.8186385,
+      "longitude": -117.8282121
+    }
+  },
+  "92868": {
+    "coordinates": {
+      "latitude": 33.78659,
+      "longitude": -117.8750976
+    }
+  },
+  "92869": {
+    "coordinates": {
+      "latitude": 33.8038894,
+      "longitude": -117.77252
+    }
+  },
+  "92870": {
+    "coordinates": {
+      "latitude": 33.8802416,
+      "longitude": -117.8604472
+    }
+  },
+  "92871": {
+    "coordinates": {
+      "latitude": 33.8882123,
+      "longitude": -117.8635147
+    }
+  },
+  "92877": {
+    "coordinates": {
+      "latitude": 33.8551027,
+      "longitude": -117.5389829
+    }
+  },
+  "92878": {
+    "coordinates": {
+      "latitude": 33.8781886,
+      "longitude": -117.5731991
+    }
+  },
+  "92879": {
+    "coordinates": {
+      "latitude": 33.8813831,
+      "longitude": -117.5378439
+    }
+  },
+  "92880": {
+    "coordinates": {
+      "latitude": 33.8998939,
+      "longitude": -117.6317494
+    }
+  },
+  "92881": {
+    "coordinates": {
+      "latitude": 33.840139,
+      "longitude": -117.5378439
+    }
+  },
+  "92882": {
+    "coordinates": {
+      "latitude": 33.84374830000001,
+      "longitude": -117.6082774
+    }
+  },
+  "92883": {
+    "coordinates": {
+      "latitude": 33.7407483,
+      "longitude": -117.4791295
+    }
+  },
+  "92885": {
+    "coordinates": {
+      "latitude": 33.8920838,
+      "longitude": -117.8192366
+    }
+  },
+  "92886": {
+    "coordinates": {
+      "latitude": 33.9011405,
+      "longitude": -117.7959713
+    }
+  },
+  "92887": {
+    "coordinates": {
+      "latitude": 33.8976995,
+      "longitude": -117.7256083
+    }
+  },
+  "92899": {
+    "coordinates": {
+      "latitude": 33.8606474,
+      "longitude": -117.8011009
+    }
+  },
+  "93001": {
+    "coordinates": {
+      "latitude": 34.2769462,
+      "longitude": -119.2769253
+    }
+  },
+  "93002": {
+    "coordinates": {
+      "latitude": 34.36,
+      "longitude": -119.3
+    }
+  },
+  "93003": {
+    "coordinates": {
+      "latitude": 34.2985355,
+      "longitude": -119.2204548
+    }
+  },
+  "93004": {
+    "coordinates": {
+      "latitude": 34.2765778,
+      "longitude": -119.1681373
+    }
+  },
+  "93005": {
+    "coordinates": {
+      "latitude": 34.25,
+      "longitude": -119.21
+    }
+  },
+  "93006": {
+    "coordinates": {
+      "latitude": 34.2798729,
+      "longitude": -119.2900152
+    }
+  },
+  "93007": {
+    "coordinates": {
+      "latitude": 34.29,
+      "longitude": -119.16
+    }
+  },
+  "93009": {
+    "coordinates": {
+      "latitude": 34.2689983,
+      "longitude": -119.2105731
+    }
+  },
+  "93010": {
+    "coordinates": {
+      "latitude": 34.2330908,
+      "longitude": -119.0809012
+    }
+  },
+  "93011": {
+    "coordinates": {
+      "latitude": 34.22000000000001,
+      "longitude": -119.04
+    }
+  },
+  "93012": {
+    "coordinates": {
+      "latitude": 34.2295937,
+      "longitude": -118.9761519
+    }
+  },
+  "93013": {
+    "coordinates": {
+      "latitude": 34.4212588,
+      "longitude": -119.4875668
+    }
+  },
+  "93014": {
+    "coordinates": {
+      "latitude": 34.4,
+      "longitude": -119.52
+    }
+  },
+  "93015": {
+    "coordinates": {
+      "latitude": 34.4163612,
+      "longitude": -118.8829816
+    }
+  },
+  "93016": {
+    "coordinates": {
+      "latitude": 34.4,
+      "longitude": -118.92
+    }
+  },
+  "93020": {
+    "coordinates": {
+      "latitude": 34.29,
+      "longitude": -118.88
+    }
+  },
+  "93021": {
+    "coordinates": {
+      "latitude": 34.2942772,
+      "longitude": -118.8829816
+    }
+  },
+  "93022": {
+    "coordinates": {
+      "latitude": 34.3925151,
+      "longitude": -119.3076098
+    }
+  },
+  "93023": {
+    "coordinates": {
+      "latitude": 34.5125711,
+      "longitude": -119.3714909
+    }
+  },
+  "93024": {
+    "coordinates": {
+      "latitude": 34.45,
+      "longitude": -119.24
+    }
+  },
+  "93030": {
+    "coordinates": {
+      "latitude": 34.2054029,
+      "longitude": -119.1681373
+    }
+  },
+  "93031": {
+    "coordinates": {
+      "latitude": 34.22000000000001,
+      "longitude": -119.18
+    }
+  },
+  "93032": {
+    "coordinates": {
+      "latitude": 34.1999903,
+      "longitude": -119.1800239
+    }
+  },
+  "93033": {
+    "coordinates": {
+      "latitude": 34.1599885,
+      "longitude": -119.1274334
+    }
+  },
+  "93034": {
+    "coordinates": {
+      "latitude": 34.18,
+      "longitude": -119.18
+    }
+  },
+  "93035": {
+    "coordinates": {
+      "latitude": 34.1903021,
+      "longitude": -119.2262667
+    }
+  },
+  "93036": {
+    "coordinates": {
+      "latitude": 34.2328937,
+      "longitude": -119.179765
+    }
+  },
+  "93040": {
+    "coordinates": {
+      "latitude": 34.5096515,
+      "longitude": -118.8363756
+    }
+  },
+  "93041": {
+    "coordinates": {
+      "latitude": 34.1451995,
+      "longitude": -119.1942983
+    }
+  },
+  "93042": {
+    "coordinates": {
+      "latitude": 33.2609258,
+      "longitude": -119.5223715
+    }
+  },
+  "93043": {
+    "coordinates": {
+      "latitude": 34.1652138,
+      "longitude": -119.2102834
+    }
+  },
+  "93044": {
+    "coordinates": {
+      "latitude": 34.15,
+      "longitude": -119.19
+    }
+  },
+  "93060": {
+    "coordinates": {
+      "latitude": 34.4089106,
+      "longitude": -119.0692659
+    }
+  },
+  "93061": {
+    "coordinates": {
+      "latitude": 34.35,
+      "longitude": -119.06
+    }
+  },
+  "93062": {
+    "coordinates": {
+      "latitude": 34.27,
+      "longitude": -118.78
+    }
+  },
+  "93063": {
+    "coordinates": {
+      "latitude": 34.275113,
+      "longitude": -118.7095413
+    }
+  },
+  "93064": {
+    "coordinates": {
+      "latitude": 34.2436893,
+      "longitude": -118.7023068
+    }
+  },
+  "93065": {
+    "coordinates": {
+      "latitude": 34.2774306,
+      "longitude": -118.7897558
+    }
+  },
+  "93066": {
+    "coordinates": {
+      "latitude": 34.2989933,
+      "longitude": -119.0227159
+    }
+  },
+  "93067": {
+    "coordinates": {
+      "latitude": 34.4205066,
+      "longitude": -119.601738
+    }
+  },
+  "93093": {
+    "coordinates": {
+      "latitude": 34.032383,
+      "longitude": -119.1343
+    }
+  },
+  "93094": {
+    "coordinates": {
+      "latitude": 34.28,
+      "longitude": -118.7
+    }
+  },
+  "93099": {
+    "coordinates": {
+      "latitude": 34.27,
+      "longitude": -118.78
+    }
+  },
+  "93101": {
+    "coordinates": {
+      "latitude": 34.420334,
+      "longitude": -119.7107494
+    }
+  },
+  "93102": {
+    "coordinates": {
+      "latitude": 34.4216024,
+      "longitude": -119.698259
+    }
+  },
+  "93103": {
+    "coordinates": {
+      "latitude": 34.433094,
+      "longitude": -119.6817845
+    }
+  },
+  "93105": {
+    "coordinates": {
+      "latitude": 34.4402467,
+      "longitude": -119.7289889
+    }
+  },
+  "93106": {
+    "coordinates": {
+      "latitude": 34.4135868,
+      "longitude": -119.8496976
+    }
+  },
+  "93107": {
+    "coordinates": {
+      "latitude": 34.42,
+      "longitude": -119.7
+    }
+  },
+  "93108": {
+    "coordinates": {
+      "latitude": 34.4381407,
+      "longitude": -119.6151426
+    }
+  },
+  "93109": {
+    "coordinates": {
+      "latitude": 34.4038383,
+      "longitude": -119.7252297
+    }
+  },
+  "93110": {
+    "coordinates": {
+      "latitude": 34.5084312,
+      "longitude": -119.7310213
+    }
+  },
+  "93111": {
+    "coordinates": {
+      "latitude": 34.4630827,
+      "longitude": -119.8062912
+    }
+  },
+  "93116": {
+    "coordinates": {
+      "latitude": 34.49,
+      "longitude": -120.04
+    }
+  },
+  "93117": {
+    "coordinates": {
+      "latitude": 34.4301656,
+      "longitude": -119.8696691
+    }
+  },
+  "93118": {
+    "coordinates": {
+      "latitude": 34.4397622,
+      "longitude": -119.8301189
+    }
+  },
+  "93120": {
+    "coordinates": {
+      "latitude": 34.42,
+      "longitude": -119.7
+    }
+  },
+  "93121": {
+    "coordinates": {
+      "latitude": 34.42,
+      "longitude": -119.7
+    }
+  },
+  "93130": {
+    "coordinates": {
+      "latitude": 34.53,
+      "longitude": -119.82
+    }
+  },
+  "93140": {
+    "coordinates": {
+      "latitude": 34.42,
+      "longitude": -119.68
+    }
+  },
+  "93150": {
+    "coordinates": {
+      "latitude": 34.44,
+      "longitude": -119.63
+    }
+  },
+  "93160": {
+    "coordinates": {
+      "latitude": 34.43,
+      "longitude": -119.8
+    }
+  },
+  "93190": {
+    "coordinates": {
+      "latitude": 34.42,
+      "longitude": -119.7
+    }
+  },
+  "93199": {
+    "coordinates": {
+      "latitude": 34.4252908,
+      "longitude": -119.8732037
+    }
+  },
+  "93201": {
+    "coordinates": {
+      "latitude": 35.86783399999999,
+      "longitude": -119.4875668
+    }
+  },
+  "93202": {
+    "coordinates": {
+      "latitude": 36.3104492,
+      "longitude": -119.7093013
+    }
+  },
+  "93203": {
+    "coordinates": {
+      "latitude": 35.0626492,
+      "longitude": -118.8130675
+    }
+  },
+  "93204": {
+    "coordinates": {
+      "latitude": 35.9822676,
+      "longitude": -120.0896313
+    }
+  },
+  "93205": {
+    "coordinates": {
+      "latitude": 35.5489716,
+      "longitude": -118.451357
+    }
+  },
+  "93206": {
+    "coordinates": {
+      "latitude": 35.4283801,
+      "longitude": -119.4875668
+    }
+  },
+  "93207": {
+    "coordinates": {
+      "latitude": 35.9013575,
+      "longitude": -118.6031402
+    }
+  },
+  "93208": {
+    "coordinates": {
+      "latitude": 36.0065338,
+      "longitude": -118.5447787
+    }
+  },
+  "93210": {
+    "coordinates": {
+      "latitude": 36.2615718,
+      "longitude": -120.4357631
+    }
+  },
+  "93212": {
+    "coordinates": {
+      "latitude": 36.0980204,
+      "longitude": -119.5603945
+    }
+  },
+  "93215": {
+    "coordinates": {
+      "latitude": 35.7949326,
+      "longitude": -119.1623231
+    }
+  },
+  "93216": {
+    "coordinates": {
+      "latitude": 35.77,
+      "longitude": -119.25
+    }
+  },
+  "93217": {
+    "coordinates": {
+      "latitude": 35.89151,
+      "longitude": -119.263225
+    }
+  },
+  "93218": {
+    "coordinates": {
+      "latitude": 35.8587055,
+      "longitude": -119.0343548
+    }
+  },
+  "93219": {
+    "coordinates": {
+      "latitude": 35.879,
+      "longitude": -119.3714909
+    }
+  },
+  "93220": {
+    "coordinates": {
+      "latitude": 35.42246859999999,
+      "longitude": -118.7081382
+    }
+  },
+  "93221": {
+    "coordinates": {
+      "latitude": 36.3101417,
+      "longitude": -119.0227159
+    }
+  },
+  "93222": {
+    "coordinates": {
+      "latitude": 34.8611703,
+      "longitude": -119.179765
+    }
+  },
+  "93223": {
+    "coordinates": {
+      "latitude": 36.3036623,
+      "longitude": -119.205924
+    }
+  },
+  "93224": {
+    "coordinates": {
+      "latitude": 35.2031054,
+      "longitude": -119.5803605
+    }
+  },
+  "93225": {
+    "coordinates": {
+      "latitude": 34.8177796,
+      "longitude": -119.0027936
+    }
+  },
+  "93226": {
+    "coordinates": {
+      "latitude": 35.756937,
+      "longitude": -118.6964752
+    }
+  },
+  "93227": {
+    "coordinates": {
+      "latitude": 36.3435879,
+      "longitude": -119.4211606
+    }
+  },
+  "93230": {
+    "coordinates": {
+      "latitude": 36.2808234,
+      "longitude": -119.6499162
+    }
+  },
+  "93231": {
+    "coordinates": {
+      "latitude": 36.138861,
+      "longitude": -119.894727
+    }
+  },
+  "93232": {
+    "coordinates": {
+      "latitude": 36.33,
+      "longitude": -119.64
+    }
+  },
+  "93234": {
+    "coordinates": {
+      "latitude": 36.1869027,
+      "longitude": -120.1011836
+    }
+  },
+  "93235": {
+    "coordinates": {
+      "latitude": 36.3899871,
+      "longitude": -119.2262667
+    }
+  },
+  "93237": {
+    "coordinates": {
+      "latitude": 36.47000000000001,
+      "longitude": -118.92
+    }
+  },
+  "93238": {
+    "coordinates": {
+      "latitude": 35.8453422,
+      "longitude": -118.5097517
+    }
+  },
+  "93239": {
+    "coordinates": {
+      "latitude": 36.1003959,
+      "longitude": -120.0202964
+    }
+  },
+  "93240": {
+    "coordinates": {
+      "latitude": 35.6283762,
+      "longitude": -118.4163103
+    }
+  },
+  "93241": {
+    "coordinates": {
+      "latitude": 35.2638398,
+      "longitude": -118.9121033
+    }
+  },
+  "93242": {
+    "coordinates": {
+      "latitude": 36.4272476,
+      "longitude": -119.7657663
+    }
+  },
+  "93243": {
+    "coordinates": {
+      "latitude": 34.7936796,
+      "longitude": -118.8363756
+    }
+  },
+  "93244": {
+    "coordinates": {
+      "latitude": 36.46896,
+      "longitude": -119.0227159
+    }
+  },
+  "93245": {
+    "coordinates": {
+      "latitude": 36.2960087,
+      "longitude": -119.8120795
+    }
+  },
+  "93246": {
+    "coordinates": {
+      "latitude": 36.2598381,
+      "longitude": -119.8945365
+    }
+  },
+  "93247": {
+    "coordinates": {
+      "latitude": 36.2059467,
+      "longitude": -119.1158017
+    }
+  },
+  "93249": {
+    "coordinates": {
+      "latitude": 35.6355,
+      "longitude": -119.9046594
+    }
+  },
+  "93250": {
+    "coordinates": {
+      "latitude": 35.6626535,
+      "longitude": -119.2088303
+    }
+  },
+  "93251": {
+    "coordinates": {
+      "latitude": 35.2998789,
+      "longitude": -119.742604
+    }
+  },
+  "93252": {
+    "coordinates": {
+      "latitude": 34.7797056,
+      "longitude": -119.2785638
+    }
+  },
+  "93254": {
+    "coordinates": {
+      "latitude": 34.973386,
+      "longitude": -119.8005027
+    }
+  },
+  "93255": {
+    "coordinates": {
+      "latitude": 35.7377864,
+      "longitude": -118.0654445
+    }
+  },
+  "93256": {
+    "coordinates": {
+      "latitude": 35.9697829,
+      "longitude": -119.2553229
+    }
+  },
+  "93257": {
+    "coordinates": {
+      "latitude": 36.0651915,
+      "longitude": -119.0167603
+    }
+  },
+  "93258": {
+    "coordinates": {
+      "latitude": 36.07,
+      "longitude": -119.02
+    }
+  },
+  "93260": {
+    "coordinates": {
+      "latitude": 35.8212195,
+      "longitude": -118.6031402
+    }
+  },
+  "93261": {
+    "coordinates": {
+      "latitude": 35.8055077,
+      "longitude": -119.1128936
+    }
+  },
+  "93262": {
+    "coordinates": {
+      "latitude": 36.5946314,
+      "longitude": -118.6964752
+    }
+  },
+  "93263": {
+    "coordinates": {
+      "latitude": 35.4901444,
+      "longitude": -119.2553229
+    }
+  },
+  "93265": {
+    "coordinates": {
+      "latitude": 36.2106674,
+      "longitude": -118.7198004
+    }
+  },
+  "93266": {
+    "coordinates": {
+      "latitude": 36.1646087,
+      "longitude": -119.8583772
+    }
+  },
+  "93267": {
+    "coordinates": {
+      "latitude": 36.1332276,
+      "longitude": -119.1274334
+    }
+  },
+  "93268": {
+    "coordinates": {
+      "latitude": 35.14243039999999,
+      "longitude": -119.4565338
+    }
+  },
+  "93270": {
+    "coordinates": {
+      "latitude": 35.93935829999999,
+      "longitude": -119.0692659
+    }
+  },
+  "93271": {
+    "coordinates": {
+      "latitude": 36.4495198,
+      "longitude": -118.7198004
+    }
+  },
+  "93272": {
+    "coordinates": {
+      "latitude": 36.0519936,
+      "longitude": -119.3947135
+    }
+  },
+  "93274": {
+    "coordinates": {
+      "latitude": 36.1973331,
+      "longitude": -119.3714909
+    }
+  },
+  "93275": {
+    "coordinates": {
+      "latitude": 36.21,
+      "longitude": -119.35
+    }
+  },
+  "93276": {
+    "coordinates": {
+      "latitude": 35.2853741,
+      "longitude": -119.3656846
+    }
+  },
+  "93277": {
+    "coordinates": {
+      "latitude": 36.3033521,
+      "longitude": -119.3831026
+    }
+  },
+  "93278": {
+    "coordinates": {
+      "latitude": 36.31,
+      "longitude": -119.31
+    }
+  },
+  "93279": {
+    "coordinates": {
+      "latitude": 36.33,
+      "longitude": -119.29
+    }
+  },
+  "93280": {
+    "coordinates": {
+      "latitude": 35.6146443,
+      "longitude": -119.464359
+    }
+  },
+  "93282": {
+    "coordinates": {
+      "latitude": 36.1,
+      "longitude": -119.56
+    }
+  },
+  "93283": {
+    "coordinates": {
+      "latitude": 35.6239573,
+      "longitude": -118.2760503
+    }
+  },
+  "93285": {
+    "coordinates": {
+      "latitude": 35.7249556,
+      "longitude": -118.5097517
+    }
+  },
+  "93286": {
+    "coordinates": {
+      "latitude": 36.4442293,
+      "longitude": -119.1158017
+    }
+  },
+  "93287": {
+    "coordinates": {
+      "latitude": 35.7326799,
+      "longitude": -118.7897558
+    }
+  },
+  "93291": {
+    "coordinates": {
+      "latitude": 36.3696012,
+      "longitude": -119.3947135
+    }
+  },
+  "93292": {
+    "coordinates": {
+      "latitude": 36.3276805,
+      "longitude": -119.2553229
+    }
+  },
+  "93301": {
+    "coordinates": {
+      "latitude": 35.3873576,
+      "longitude": -119.0168962
+    }
+  },
+  "93302": {
+    "coordinates": {
+      "latitude": 35.55,
+      "longitude": -118.92
+    }
+  },
+  "93303": {
+    "coordinates": {
+      "latitude": 35.55,
+      "longitude": -118.92
+    }
+  },
+  "93304": {
+    "coordinates": {
+      "latitude": 35.344108,
+      "longitude": -119.0285355
+    }
+  },
+  "93305": {
+    "coordinates": {
+      "latitude": 35.3964972,
+      "longitude": -118.9819731
+    }
+  },
+  "93306": {
+    "coordinates": {
+      "latitude": 35.4516124,
+      "longitude": -118.7897558
+    }
+  },
+  "93307": {
+    "coordinates": {
+      "latitude": 35.2421103,
+      "longitude": -118.9761519
+    }
+  },
+  "93308": {
+    "coordinates": {
+      "latitude": 35.5217431,
+      "longitude": -118.9062794
+    }
+  },
+  "93309": {
+    "coordinates": {
+      "latitude": 35.3515611,
+      "longitude": -119.0576298
+    }
+  },
+  "93311": {
+    "coordinates": {
+      "latitude": 35.1268513,
+      "longitude": -119.1855785
+    }
+  },
+  "93312": {
+    "coordinates": {
+      "latitude": 35.3734151,
+      "longitude": -119.1274334
+    }
+  },
+  "93313": {
+    "coordinates": {
+      "latitude": 35.1090685,
+      "longitude": -119.0227159
+    }
+  },
+  "93325": {
+    "coordinates": {
+      "latitude": 34.819232,
+      "longitude": -119.000391
+    }
+  },
+  "93380": {
+    "coordinates": {
+      "latitude": 35.4362601,
+      "longitude": -119.0685503
+    }
+  },
+  "93381": {
+    "coordinates": {
+      "latitude": 35.294405,
+      "longitude": -118.905173
+    }
+  },
+  "93382": {
+    "coordinates": {
+      "latitude": 35.294405,
+      "longitude": -118.905173
+    }
+  },
+  "93383": {
+    "coordinates": {
+      "latitude": 35.33,
+      "longitude": -119.09
+    }
+  },
+  "93384": {
+    "coordinates": {
+      "latitude": 35.37,
+      "longitude": -119.02
+    }
+  },
+  "93385": {
+    "coordinates": {
+      "latitude": 35.38,
+      "longitude": -118.99
+    }
+  },
+  "93386": {
+    "coordinates": {
+      "latitude": 35.38,
+      "longitude": -118.95
+    }
+  },
+  "93387": {
+    "coordinates": {
+      "latitude": 35.29,
+      "longitude": -118.97
+    }
+  },
+  "93388": {
+    "coordinates": {
+      "latitude": 35.47,
+      "longitude": -118.97
+    }
+  },
+  "93389": {
+    "coordinates": {
+      "latitude": 35.35,
+      "longitude": -119.06
+    }
+  },
+  "93390": {
+    "coordinates": {
+      "latitude": 35.34,
+      "longitude": -119.06
+    }
+  },
+  "93401": {
+    "coordinates": {
+      "latitude": 35.2454989,
+      "longitude": -120.5969758
+    }
+  },
+  "93402": {
+    "coordinates": {
+      "latitude": 35.2873476,
+      "longitude": -120.8384093
+    }
+  },
+  "93403": {
+    "coordinates": {
+      "latitude": 35.28,
+      "longitude": -120.66
+    }
+  },
+  "93405": {
+    "coordinates": {
+      "latitude": 35.2994482,
+      "longitude": -120.6890055
+    }
+  },
+  "93406": {
+    "coordinates": {
+      "latitude": 35.28,
+      "longitude": -120.66
+    }
+  },
+  "93407": {
+    "coordinates": {
+      "latitude": 35.3041998,
+      "longitude": -120.6631289
+    }
+  },
+  "93408": {
+    "coordinates": {
+      "latitude": 35.2826192,
+      "longitude": -120.6613318
+    }
+  },
+  "93409": {
+    "coordinates": {
+      "latitude": 35.22,
+      "longitude": -120.64
+    }
+  },
+  "93410": {
+    "coordinates": {
+      "latitude": 35.2950035,
+      "longitude": -120.6548617
+    }
+  },
+  "93412": {
+    "coordinates": {
+      "latitude": 35.31,
+      "longitude": -120.83
+    }
+  },
+  "93420": {
+    "coordinates": {
+      "latitude": 35.1777937,
+      "longitude": -120.4818446
+    }
+  },
+  "93421": {
+    "coordinates": {
+      "latitude": 35.12,
+      "longitude": -120.59
+    }
+  },
+  "93422": {
+    "coordinates": {
+      "latitude": 35.4652141,
+      "longitude": -120.7005044
+    }
+  },
+  "93423": {
+    "coordinates": {
+      "latitude": 35.48999999999999,
+      "longitude": -120.67
+    }
+  },
+  "93424": {
+    "coordinates": {
+      "latitude": 35.1815797,
+      "longitude": -120.7299657
+    }
+  },
+  "93426": {
+    "coordinates": {
+      "latitude": 35.8425661,
+      "longitude": -120.9417368
+    }
+  },
+  "93427": {
+    "coordinates": {
+      "latitude": 34.6195028,
+      "longitude": -120.2166519
+    }
+  },
+  "93428": {
+    "coordinates": {
+      "latitude": 35.5925142,
+      "longitude": -121.0564425
+    }
+  },
+  "93429": {
+    "coordinates": {
+      "latitude": 34.8454172,
+      "longitude": -120.5451797
+    }
+  },
+  "93430": {
+    "coordinates": {
+      "latitude": 35.4731575,
+      "longitude": -120.9187827
+    }
+  },
+  "93432": {
+    "coordinates": {
+      "latitude": 35.4830274,
+      "longitude": -120.4588059
+    }
+  },
+  "93433": {
+    "coordinates": {
+      "latitude": 35.1227524,
+      "longitude": -120.617113
+    }
+  },
+  "93434": {
+    "coordinates": {
+      "latitude": 34.9529067,
+      "longitude": -120.6084832
+    }
+  },
+  "93435": {
+    "coordinates": {
+      "latitude": 35.5033829,
+      "longitude": -121.0392436
+    }
+  },
+  "93436": {
+    "coordinates": {
+      "latitude": 34.6425797,
+      "longitude": -120.3896651
+    }
+  },
+  "93437": {
+    "coordinates": {
+      "latitude": 34.7386458,
+      "longitude": -120.5509358
+    }
+  },
+  "93438": {
+    "coordinates": {
+      "latitude": 34.64,
+      "longitude": -120.46
+    }
+  },
+  "93440": {
+    "coordinates": {
+      "latitude": 34.7445591,
+      "longitude": -120.2779508
+    }
+  },
+  "93441": {
+    "coordinates": {
+      "latitude": 34.7761654,
+      "longitude": -119.9913964
+    }
+  },
+  "93442": {
+    "coordinates": {
+      "latitude": 35.4197336,
+      "longitude": -120.8269231
+    }
+  },
+  "93443": {
+    "coordinates": {
+      "latitude": 35.37,
+      "longitude": -120.85
+    }
+  },
+  "93444": {
+    "coordinates": {
+      "latitude": 35.0443612,
+      "longitude": -120.4588059
+    }
+  },
+  "93445": {
+    "coordinates": {
+      "latitude": 35.0729544,
+      "longitude": -120.6257423
+    }
+  },
+  "93446": {
+    "coordinates": {
+      "latitude": 35.6573145,
+      "longitude": -120.7579834
+    }
+  },
+  "93447": {
+    "coordinates": {
+      "latitude": 35.6204471,
+      "longitude": -120.6895538
+    }
+  },
+  "93448": {
+    "coordinates": {
+      "latitude": 35.14,
+      "longitude": -120.64
+    }
+  },
+  "93449": {
+    "coordinates": {
+      "latitude": 35.16628600000001,
+      "longitude": -120.6487508
+    }
+  },
+  "93450": {
+    "coordinates": {
+      "latitude": 35.97384900000001,
+      "longitude": -120.8269231
+    }
+  },
+  "93451": {
+    "coordinates": {
+      "latitude": 35.8674281,
+      "longitude": -120.5739579
+    }
+  },
+  "93452": {
+    "coordinates": {
+      "latitude": 35.7112777,
+      "longitude": -121.193945
+    }
+  },
+  "93453": {
+    "coordinates": {
+      "latitude": 35.4137653,
+      "longitude": -120.2051096
+    }
+  },
+  "93454": {
+    "coordinates": {
+      "latitude": 34.9339263,
+      "longitude": -120.2051096
+    }
+  },
+  "93455": {
+    "coordinates": {
+      "latitude": 34.8442407,
+      "longitude": -120.4588059
+    }
+  },
+  "93456": {
+    "coordinates": {
+      "latitude": 34.9314379,
+      "longitude": -120.4348244
+    }
+  },
+  "93457": {
+    "coordinates": {
+      "latitude": 34.86,
+      "longitude": -120.44
+    }
+  },
+  "93458": {
+    "coordinates": {
+      "latitude": 34.9648191,
+      "longitude": -120.4933624
+    }
+  },
+  "93460": {
+    "coordinates": {
+      "latitude": 34.6627116,
+      "longitude": -120.0202964
+    }
+  },
+  "93461": {
+    "coordinates": {
+      "latitude": 35.6271932,
+      "longitude": -120.2974199
+    }
+  },
+  "93463": {
+    "coordinates": {
+      "latitude": 34.6182169,
+      "longitude": -120.147383
+    }
+  },
+  "93464": {
+    "coordinates": {
+      "latitude": 34.6,
+      "longitude": -120.14
+    }
+  },
+  "93465": {
+    "coordinates": {
+      "latitude": 35.5316951,
+      "longitude": -120.7464897
+    }
+  },
+  "93483": {
+    "coordinates": {
+      "latitude": 35.12,
+      "longitude": -120.62
+    }
+  },
+  "93492": {
+    "coordinates": {
+      "latitude": 35.372861,
+      "longitude": -120.859391
+    }
+  },
+  "93501": {
+    "coordinates": {
+      "latitude": 35.04403,
+      "longitude": -118.2526623
+    }
+  },
+  "93502": {
+    "coordinates": {
+      "latitude": 35.05,
+      "longitude": -118.17
+    }
+  },
+  "93504": {
+    "coordinates": {
+      "latitude": 35.13,
+      "longitude": -117.99
+    }
+  },
+  "93505": {
+    "coordinates": {
+      "latitude": 35.1146082,
+      "longitude": -117.9717606
+    }
+  },
+  "93510": {
+    "coordinates": {
+      "latitude": 34.4600722,
+      "longitude": -118.2292712
+    }
+  },
+  "93512": {
+    "coordinates": {
+      "latitude": 37.89090180000001,
+      "longitude": -118.5564526
+    }
+  },
+  "93513": {
+    "coordinates": {
+      "latitude": 37.0710057,
+      "longitude": -118.1590786
+    }
+  },
+  "93514": {
+    "coordinates": {
+      "latitude": 37.361495,
+      "longitude": -118.4012724
+    }
+  },
+  "93515": {
+    "coordinates": {
+      "latitude": 37.36,
+      "longitude": -118.39
+    }
+  },
+  "93516": {
+    "coordinates": {
+      "latitude": 35.00735270000001,
+      "longitude": -117.666952
+    }
+  },
+  "93517": {
+    "coordinates": {
+      "latitude": 38.286368,
+      "longitude": -119.3250347
+    }
+  },
+  "93518": {
+    "coordinates": {
+      "latitude": 35.4008617,
+      "longitude": -118.4396756
+    }
+  },
+  "93519": {
+    "coordinates": {
+      "latitude": 35.3028869,
+      "longitude": -117.9483319
+    }
+  },
+  "93522": {
+    "coordinates": {
+      "latitude": 36.311674,
+      "longitude": -117.6200138
+    }
+  },
+  "93523": {
+    "coordinates": {
+      "latitude": 34.9609579,
+      "longitude": -117.8545867
+    }
+  },
+  "93524": {
+    "coordinates": {
+      "latitude": 34.9326031,
+      "longitude": -117.9073244
+    }
+  },
+  "93526": {
+    "coordinates": {
+      "latitude": 36.8091742,
+      "longitude": -118.2526623
+    }
+  },
+  "93527": {
+    "coordinates": {
+      "latitude": 36.1155819,
+      "longitude": -118.1590786
+    }
+  },
+  "93528": {
+    "coordinates": {
+      "latitude": 35.3714792,
+      "longitude": -117.6317494
+    }
+  },
+  "93529": {
+    "coordinates": {
+      "latitude": 37.8130468,
+      "longitude": -119.1041691
+    }
+  },
+  "93530": {
+    "coordinates": {
+      "latitude": 36.4971356,
+      "longitude": -117.8868171
+    }
+  },
+  "93531": {
+    "coordinates": {
+      "latitude": 35.224821,
+      "longitude": -118.61481
+    }
+  },
+  "93532": {
+    "coordinates": {
+      "latitude": 34.676617,
+      "longitude": -118.4531942
+    }
+  },
+  "93534": {
+    "coordinates": {
+      "latitude": 34.6946278,
+      "longitude": -118.1473771
+    }
+  },
+  "93535": {
+    "coordinates": {
+      "latitude": 34.7311394,
+      "longitude": -117.8780275
+    }
+  },
+  "93536": {
+    "coordinates": {
+      "latitude": 34.7190908,
+      "longitude": -118.2526623
+    }
+  },
+  "93539": {
+    "coordinates": {
+      "latitude": 34.6824502,
+      "longitude": -118.1656706
+    }
+  },
+  "93540": {
+    "coordinates": {
+      "latitude": 35.60345,
+      "longitude": -118.476436
+    }
+  },
+  "93541": {
+    "coordinates": {
+      "latitude": 38.0009125,
+      "longitude": -119.0925356
+    }
+  },
+  "93542": {
+    "coordinates": {
+      "latitude": 35.94,
+      "longitude": -117.91
+    }
+  },
+  "93543": {
+    "coordinates": {
+      "latitude": 34.4965114,
+      "longitude": -117.9600466
+    }
+  },
+  "93544": {
+    "coordinates": {
+      "latitude": 34.494562,
+      "longitude": -117.7607932
+    }
+  },
+  "93545": {
+    "coordinates": {
+      "latitude": 36.5131184,
+      "longitude": -118.0888578
+    }
+  },
+  "93546": {
+    "coordinates": {
+      "latitude": 37.5822629,
+      "longitude": -118.8363756
+    }
+  },
+  "93549": {
+    "coordinates": {
+      "latitude": 36.163149,
+      "longitude": -117.9717606
+    }
+  },
+  "93550": {
+    "coordinates": {
+      "latitude": 34.3579404,
+      "longitude": -118.0654445
+    }
+  },
+  "93551": {
+    "coordinates": {
+      "latitude": 34.594158,
+      "longitude": -118.1824793
+    }
+  },
+  "93552": {
+    "coordinates": {
+      "latitude": 34.5811542,
+      "longitude": -118.0303189
+    }
+  },
+  "93553": {
+    "coordinates": {
+      "latitude": 34.3780816,
+      "longitude": -117.9014654
+    }
+  },
+  "93554": {
+    "coordinates": {
+      "latitude": 35.3901517,
+      "longitude": -117.7607932
+    }
+  },
+  "93555": {
+    "coordinates": {
+      "latitude": 35.5897118,
+      "longitude": -117.6904167
+    }
+  },
+  "93556": {
+    "coordinates": {
+      "latitude": 35.62,
+      "longitude": -117.67
+    }
+  },
+  "93558": {
+    "coordinates": {
+      "latitude": 35.37,
+      "longitude": -117.63
+    }
+  },
+  "93560": {
+    "coordinates": {
+      "latitude": 34.8843005,
+      "longitude": -118.3228165
+    }
+  },
+  "93561": {
+    "coordinates": {
+      "latitude": 35.0776145,
+      "longitude": -118.4396756
+    }
+  },
+  "93562": {
+    "coordinates": {
+      "latitude": 35.76615779999999,
+      "longitude": -117.3851496
+    }
+  },
+  "93563": {
+    "coordinates": {
+      "latitude": 34.4053384,
+      "longitude": -117.7490656
+    }
+  },
+  "93564": {
+    "coordinates": {
+      "latitude": 34.900151,
+      "longitude": -118.246691
+    }
+  },
+  "93581": {
+    "coordinates": {
+      "latitude": 35.13,
+      "longitude": -118.45
+    }
+  },
+  "93584": {
+    "coordinates": {
+      "latitude": 34.7,
+      "longitude": -118.14
+    }
+  },
+  "93586": {
+    "coordinates": {
+      "latitude": 34.65,
+      "longitude": -118.22
+    }
+  },
+  "93590": {
+    "coordinates": {
+      "latitude": 34.5,
+      "longitude": -118.06
+    }
+  },
+  "93591": {
+    "coordinates": {
+      "latitude": 34.5925622,
+      "longitude": -117.8194197
+    }
+  },
+  "93592": {
+    "coordinates": {
+      "latitude": 35.9218986,
+      "longitude": -117.2440957
+    }
+  },
+  "93596": {
+    "coordinates": {
+      "latitude": 35,
+      "longitude": -117.65
+    }
+  },
+  "93599": {
+    "coordinates": {
+      "latitude": 34.6149957,
+      "longitude": -118.1093418
+    }
+  },
+  "93601": {
+    "coordinates": {
+      "latitude": 37.38881900000001,
+      "longitude": -119.7310213
+    }
+  },
+  "93602": {
+    "coordinates": {
+      "latitude": 37.0795598,
+      "longitude": -119.3947135
+    }
+  },
+  "93603": {
+    "coordinates": {
+      "latitude": 36.6002176,
+      "longitude": -118.9761519
+    }
+  },
+  "93604": {
+    "coordinates": {
+      "latitude": 37.4067748,
+      "longitude": -119.4875668
+    }
+  },
+  "93605": {
+    "coordinates": {
+      "latitude": 37.1890642,
+      "longitude": -119.2437011
+    }
+  },
+  "93606": {
+    "coordinates": {
+      "latitude": 36.8021801,
+      "longitude": -120.016323
+    }
+  },
+  "93607": {
+    "coordinates": {
+      "latitude": 36.48999999999999,
+      "longitude": -119.98
+    }
+  },
+  "93608": {
+    "coordinates": {
+      "latitude": 36.4974358,
+      "longitude": -120.3666099
+    }
+  },
+  "93609": {
+    "coordinates": {
+      "latitude": 36.52027750000001,
+      "longitude": -119.8583772
+    }
+  },
+  "93610": {
+    "coordinates": {
+      "latitude": 37.1108483,
+      "longitude": -120.2743484
+    }
+  },
+  "93611": {
+    "coordinates": {
+      "latitude": 36.8303133,
+      "longitude": -119.6788877
+    }
+  },
+  "93612": {
+    "coordinates": {
+      "latitude": 36.8109736,
+      "longitude": -119.7136456
+    }
+  },
+  "93613": {
+    "coordinates": {
+      "latitude": 36.82,
+      "longitude": -119.71
+    }
+  },
+  "93614": {
+    "coordinates": {
+      "latitude": 37.2000816,
+      "longitude": -119.742604
+    }
+  },
+  "93615": {
+    "coordinates": {
+      "latitude": 36.5065822,
+      "longitude": -119.2901829
+    }
+  },
+  "93616": {
+    "coordinates": {
+      "latitude": 36.642368,
+      "longitude": -119.5919555
+    }
+  },
+  "93618": {
+    "coordinates": {
+      "latitude": 36.5279315,
+      "longitude": -119.3947135
+    }
+  },
+  "93620": {
+    "coordinates": {
+      "latitude": 37.0455625,
+      "longitude": -120.6429991
+    }
+  },
+  "93621": {
+    "coordinates": {
+      "latitude": 36.8003047,
+      "longitude": -119.1158017
+    }
+  },
+  "93622": {
+    "coordinates": {
+      "latitude": 36.8114708,
+      "longitude": -120.5739579
+    }
+  },
+  "93623": {
+    "coordinates": {
+      "latitude": 37.4923214,
+      "longitude": -119.638326
+    }
+  },
+  "93624": {
+    "coordinates": {
+      "latitude": 36.3976444,
+      "longitude": -120.1242853
+    }
+  },
+  "93625": {
+    "coordinates": {
+      "latitude": 36.6234291,
+      "longitude": -119.6615055
+    }
+  },
+  "93626": {
+    "coordinates": {
+      "latitude": 37.0429444,
+      "longitude": -119.6730939
+    }
+  },
+  "93627": {
+    "coordinates": {
+      "latitude": 36.5158276,
+      "longitude": -120.1242853
+    }
+  },
+  "93628": {
+    "coordinates": {
+      "latitude": 36.7708505,
+      "longitude": -118.9295737
+    }
+  },
+  "93630": {
+    "coordinates": {
+      "latitude": 36.7057988,
+      "longitude": -120.112735
+    }
+  },
+  "93631": {
+    "coordinates": {
+      "latitude": 36.4903097,
+      "longitude": -119.5339711
+    }
+  },
+  "93633": {
+    "coordinates": {
+      "latitude": 36.8118588,
+      "longitude": -118.6614809
+    }
+  },
+  "93634": {
+    "coordinates": {
+      "latitude": 37.2964837,
+      "longitude": -118.9528645
+    }
+  },
+  "93635": {
+    "coordinates": {
+      "latitude": 37.0583373,
+      "longitude": -120.8499249
+    }
+  },
+  "93637": {
+    "coordinates": {
+      "latitude": 36.9152938,
+      "longitude": -120.2051096
+    }
+  },
+  "93638": {
+    "coordinates": {
+      "latitude": 37.0190777,
+      "longitude": -120.043412
+    }
+  },
+  "93639": {
+    "coordinates": {
+      "latitude": 36.96,
+      "longitude": -120.06
+    }
+  },
+  "93640": {
+    "coordinates": {
+      "latitude": 36.6807956,
+      "longitude": -120.4127161
+    }
+  },
+  "93641": {
+    "coordinates": {
+      "latitude": 36.706587,
+      "longitude": -119.0227159
+    }
+  },
+  "93642": {
+    "coordinates": {
+      "latitude": 37.26966,
+      "longitude": -119.12564
+    }
+  },
+  "93643": {
+    "coordinates": {
+      "latitude": 37.2238226,
+      "longitude": -119.4411476
+    }
+  },
+  "93644": {
+    "coordinates": {
+      "latitude": 37.3686993,
+      "longitude": -119.6267347
+    }
+  },
+  "93645": {
+    "coordinates": {
+      "latitude": 37.1602241,
+      "longitude": -119.638326
+    }
+  },
+  "93646": {
+    "coordinates": {
+      "latitude": 36.6319889,
+      "longitude": -119.3018011
+    }
+  },
+  "93647": {
+    "coordinates": {
+      "latitude": 36.5902725,
+      "longitude": -119.1623231
+    }
+  },
+  "93648": {
+    "coordinates": {
+      "latitude": 36.6218128,
+      "longitude": -119.5223715
+    }
+  },
+  "93649": {
+    "coordinates": {
+      "latitude": 36.8226391,
+      "longitude": -119.3626865
+    }
+  },
+  "93650": {
+    "coordinates": {
+      "latitude": 36.8420172,
+      "longitude": -119.8019498
+    }
+  },
+  "93651": {
+    "coordinates": {
+      "latitude": 36.995809,
+      "longitude": -119.5223715
+    }
+  },
+  "93652": {
+    "coordinates": {
+      "latitude": 36.5897007,
+      "longitude": -119.9104436
+    }
+  },
+  "93653": {
+    "coordinates": {
+      "latitude": 37.2270871,
+      "longitude": -119.9277947
+    }
+  },
+  "93654": {
+    "coordinates": {
+      "latitude": 36.64647,
+      "longitude": -119.3947135
+    }
+  },
+  "93656": {
+    "coordinates": {
+      "latitude": 36.4553949,
+      "longitude": -119.950926
+    }
+  },
+  "93657": {
+    "coordinates": {
+      "latitude": 36.7916817,
+      "longitude": -119.4411476
+    }
+  },
+  "93660": {
+    "coordinates": {
+      "latitude": 36.58829490000001,
+      "longitude": -120.182022
+    }
+  },
+  "93661": {
+    "coordinates": {
+      "latitude": 37.047906,
+      "longitude": -120.6244271
+    }
+  },
+  "93662": {
+    "coordinates": {
+      "latitude": 36.5441315,
+      "longitude": -119.6267347
+    }
+  },
+  "93664": {
+    "coordinates": {
+      "latitude": 37.0875479,
+      "longitude": -118.9994357
+    }
+  },
+  "93665": {
+    "coordinates": {
+      "latitude": 36.9633372,
+      "longitude": -120.6513203
+    }
+  },
+  "93666": {
+    "coordinates": {
+      "latitude": 36.5450389,
+      "longitude": -119.3391908
+    }
+  },
+  "93667": {
+    "coordinates": {
+      "latitude": 36.9349122,
+      "longitude": -119.3482646
+    }
+  },
+  "93668": {
+    "coordinates": {
+      "latitude": 36.6411184,
+      "longitude": -120.2743484
+    }
+  },
+  "93669": {
+    "coordinates": {
+      "latitude": 37.2703531,
+      "longitude": -119.5397706
+    }
+  },
+  "93670": {
+    "coordinates": {
+      "latitude": 36.4865608,
+      "longitude": -119.2500569
+    }
+  },
+  "93673": {
+    "coordinates": {
+      "latitude": 36.4536184,
+      "longitude": -119.4857538
+    }
+  },
+  "93675": {
+    "coordinates": {
+      "latitude": 36.7359348,
+      "longitude": -119.2088303
+    }
+  },
+  "93688": {
+    "coordinates": {
+      "latitude": 36.648474,
+      "longitude": -120.248818
+    }
+  },
+  "93701": {
+    "coordinates": {
+      "latitude": 36.7509383,
+      "longitude": -119.7802409
+    }
+  },
+  "93702": {
+    "coordinates": {
+      "latitude": 36.7491199,
+      "longitude": -119.7599761
+    }
+  },
+  "93703": {
+    "coordinates": {
+      "latitude": 36.7687871,
+      "longitude": -119.7599761
+    }
+  },
+  "93704": {
+    "coordinates": {
+      "latitude": 36.7757374,
+      "longitude": -119.8062912
+    }
+  },
+  "93705": {
+    "coordinates": {
+      "latitude": 36.789028,
+      "longitude": -119.829443
+    }
+  },
+  "93706": {
+    "coordinates": {
+      "latitude": 36.67839379999999,
+      "longitude": -119.9277947
+    }
+  },
+  "93707": {
+    "coordinates": {
+      "latitude": 36.7299999,
+      "longitude": -119.78
+    }
+  },
+  "93708": {
+    "coordinates": {
+      "latitude": 36.7299999,
+      "longitude": -119.78
+    }
+  },
+  "93709": {
+    "coordinates": {
+      "latitude": 36.7299999,
+      "longitude": -119.78
+    }
+  },
+  "93710": {
+    "coordinates": {
+      "latitude": 36.8179331,
+      "longitude": -119.7599761
+    }
+  },
+  "93711": {
+    "coordinates": {
+      "latitude": 36.8381393,
+      "longitude": -119.829443
+    }
+  },
+  "93712": {
+    "coordinates": {
+      "latitude": 36.7299999,
+      "longitude": -119.78
+    }
+  },
+  "93714": {
+    "coordinates": {
+      "latitude": 36.7299999,
+      "longitude": -119.78
+    }
+  },
+  "93715": {
+    "coordinates": {
+      "latitude": 36.7299999,
+      "longitude": -119.78
+    }
+  },
+  "93716": {
+    "coordinates": {
+      "latitude": 36.7299999,
+      "longitude": -119.78
+    }
+  },
+  "93717": {
+    "coordinates": {
+      "latitude": 36.7299999,
+      "longitude": -119.78
+    }
+  },
+  "93718": {
+    "coordinates": {
+      "latitude": 36.7299999,
+      "longitude": -119.78
+    }
+  },
+  "93720": {
+    "coordinates": {
+      "latitude": 36.8638688,
+      "longitude": -119.7715563
+    }
+  },
+  "93721": {
+    "coordinates": {
+      "latitude": 36.7337663,
+      "longitude": -119.7845829
+    }
+  },
+  "93722": {
+    "coordinates": {
+      "latitude": 36.8353312,
+      "longitude": -119.8930904
+    }
+  },
+  "93724": {
+    "coordinates": {
+      "latitude": 36.7366792,
+      "longitude": -119.7896485
+    }
+  },
+  "93725": {
+    "coordinates": {
+      "latitude": 36.6765725,
+      "longitude": -119.7194377
+    }
+  },
+  "93726": {
+    "coordinates": {
+      "latitude": 36.7949518,
+      "longitude": -119.7541856
+    }
+  },
+  "93727": {
+    "coordinates": {
+      "latitude": 36.7486376,
+      "longitude": -119.7078532
+    }
+  },
+  "93728": {
+    "coordinates": {
+      "latitude": 36.7545601,
+      "longitude": -119.8207615
+    }
+  },
+  "93729": {
+    "coordinates": {
+      "latitude": 36.8518417,
+      "longitude": -119.771181
+    }
+  },
+  "93740": {
+    "coordinates": {
+      "latitude": 36.8129075,
+      "longitude": -119.7469472
+    }
+  },
+  "93741": {
+    "coordinates": {
+      "latitude": 36.766849,
+      "longitude": -119.7994084
+    }
+  },
+  "93744": {
+    "coordinates": {
+      "latitude": 36.76,
+      "longitude": -119.8
+    }
+  },
+  "93745": {
+    "coordinates": {
+      "latitude": 36.63,
+      "longitude": -119.74
+    }
+  },
+  "93747": {
+    "coordinates": {
+      "latitude": 36.73999999999999,
+      "longitude": -119.7
+    }
+  },
+  "93750": {
+    "coordinates": {
+      "latitude": 36.7375793,
+      "longitude": -119.752738
+    }
+  },
+  "93755": {
+    "coordinates": {
+      "latitude": 36.79,
+      "longitude": -119.79
+    }
+  },
+  "93759": {
+    "coordinates": {
+      "latitude": 36.746375,
+      "longitude": -119.639658
+    }
+  },
+  "93760": {
+    "coordinates": {
+      "latitude": 36.734967,
+      "longitude": -119.7813264
+    }
+  },
+  "93761": {
+    "coordinates": {
+      "latitude": 36.7507018,
+      "longitude": -119.7883821
+    }
+  },
+  "93762": {
+    "coordinates": {
+      "latitude": 36.746375,
+      "longitude": -119.639658
+    }
+  },
+  "93764": {
+    "coordinates": {
+      "latitude": 36.7369629,
+      "longitude": -119.7869348
+    }
+  },
+  "93765": {
+    "coordinates": {
+      "latitude": 36.8076898,
+      "longitude": -119.8341452
+    }
+  },
+  "93771": {
+    "coordinates": {
+      "latitude": 36.73999999999999,
+      "longitude": -119.8
+    }
+  },
+  "93772": {
+    "coordinates": {
+      "latitude": 36.73999999999999,
+      "longitude": -119.8
+    }
+  },
+  "93773": {
+    "coordinates": {
+      "latitude": 36.73999999999999,
+      "longitude": -119.8
+    }
+  },
+  "93774": {
+    "coordinates": {
+      "latitude": 36.73999999999999,
+      "longitude": -119.8
+    }
+  },
+  "93775": {
+    "coordinates": {
+      "latitude": 36.73999999999999,
+      "longitude": -119.8
+    }
+  },
+  "93776": {
+    "coordinates": {
+      "latitude": 36.73999999999999,
+      "longitude": -119.8
+    }
+  },
+  "93777": {
+    "coordinates": {
+      "latitude": 36.73999999999999,
+      "longitude": -119.8
+    }
+  },
+  "93778": {
+    "coordinates": {
+      "latitude": 36.73999999999999,
+      "longitude": -119.8
+    }
+  },
+  "93779": {
+    "coordinates": {
+      "latitude": 36.73999999999999,
+      "longitude": -119.8
+    }
+  },
+  "93780": {
+    "coordinates": {
+      "latitude": 36.746375,
+      "longitude": -119.639658
+    }
+  },
+  "93782": {
+    "coordinates": {
+      "latitude": 36.746375,
+      "longitude": -119.639658
+    }
+  },
+  "93784": {
+    "coordinates": {
+      "latitude": 36.746375,
+      "longitude": -119.639658
+    }
+  },
+  "93786": {
+    "coordinates": {
+      "latitude": 36.738853,
+      "longitude": -119.8041205
+    }
+  },
+  "93790": {
+    "coordinates": {
+      "latitude": 36.79,
+      "longitude": -119.83
+    }
+  },
+  "93791": {
+    "coordinates": {
+      "latitude": 36.79,
+      "longitude": -119.83
+    }
+  },
+  "93792": {
+    "coordinates": {
+      "latitude": 36.79,
+      "longitude": -119.83
+    }
+  },
+  "93793": {
+    "coordinates": {
+      "latitude": 36.79,
+      "longitude": -119.83
+    }
+  },
+  "93794": {
+    "coordinates": {
+      "latitude": 36.79,
+      "longitude": -119.83
+    }
+  },
+  "93825": {
+    "coordinates": {
+      "latitude": 35.717406,
+      "longitude": -118.466755
+    }
+  },
+  "93844": {
+    "coordinates": {
+      "latitude": 36.7287119,
+      "longitude": -119.7248076
+    }
+  },
+  "93888": {
+    "coordinates": {
+      "latitude": 36.7307718,
+      "longitude": -119.7259536
+    }
+  },
+  "93901": {
+    "coordinates": {
+      "latitude": 36.6623815,
+      "longitude": -121.6454222
+    }
+  },
+  "93902": {
+    "coordinates": {
+      "latitude": 36.78,
+      "longitude": -121.66
+    }
+  },
+  "93905": {
+    "coordinates": {
+      "latitude": 36.685567,
+      "longitude": -121.5997835
+    }
+  },
+  "93906": {
+    "coordinates": {
+      "latitude": 36.7272444,
+      "longitude": -121.6397184
+    }
+  },
+  "93907": {
+    "coordinates": {
+      "latitude": 36.7918545,
+      "longitude": -121.6511258
+    }
+  },
+  "93908": {
+    "coordinates": {
+      "latitude": 36.5981753,
+      "longitude": -121.5826642
+    }
+  },
+  "93912": {
+    "coordinates": {
+      "latitude": 36.7,
+      "longitude": -121.67
+    }
+  },
+  "93915": {
+    "coordinates": {
+      "latitude": 36.67,
+      "longitude": -121.63
+    }
+  },
+  "93920": {
+    "coordinates": {
+      "latitude": 36.0514956,
+      "longitude": -121.5141615
+    }
+  },
+  "93921": {
+    "coordinates": {
+      "latitude": 36.5569,
+      "longitude": -121.92269
+    }
+  },
+  "93922": {
+    "coordinates": {
+      "latitude": 36.45,
+      "longitude": -121.84
+    }
+  },
+  "93923": {
+    "coordinates": {
+      "latitude": 36.4656419,
+      "longitude": -121.8334868
+    }
+  },
+  "93924": {
+    "coordinates": {
+      "latitude": 36.4799547,
+      "longitude": -121.7327145
+    }
+  },
+  "93925": {
+    "coordinates": {
+      "latitude": 36.5999881,
+      "longitude": -121.3770336
+    }
+  },
+  "93926": {
+    "coordinates": {
+      "latitude": 36.5283778,
+      "longitude": -121.3884671
+    }
+  },
+  "93927": {
+    "coordinates": {
+      "latitude": 36.1828098,
+      "longitude": -121.3998995
+    }
+  },
+  "93928": {
+    "coordinates": {
+      "latitude": 36.0067552,
+      "longitude": -121.2282958
+    }
+  },
+  "93930": {
+    "coordinates": {
+      "latitude": 36.2143294,
+      "longitude": -121.1237187
+    }
+  },
+  "93932": {
+    "coordinates": {
+      "latitude": 36.0397645,
+      "longitude": -121.0105733
+    }
+  },
+  "93933": {
+    "coordinates": {
+      "latitude": 36.680194,
+      "longitude": -121.7822278
+    }
+  },
+  "93940": {
+    "coordinates": {
+      "latitude": 36.5760412,
+      "longitude": -121.822098
+    }
+  },
+  "93942": {
+    "coordinates": {
+      "latitude": 36.61,
+      "longitude": -121.9
+    }
+  },
+  "93943": {
+    "coordinates": {
+      "latitude": 36.5964368,
+      "longitude": -121.8740501
+    }
+  },
+  "93944": {
+    "coordinates": {
+      "latitude": 36.6031809,
+      "longitude": -121.9145986
+    }
+  },
+  "93950": {
+    "coordinates": {
+      "latitude": 36.62011800000001,
+      "longitude": -121.918866
+    }
+  },
+  "93953": {
+    "coordinates": {
+      "latitude": 36.5841937,
+      "longitude": -121.9416226
+    }
+  },
+  "93954": {
+    "coordinates": {
+      "latitude": 36.1184726,
+      "longitude": -120.9589496
+    }
+  },
+  "93955": {
+    "coordinates": {
+      "latitude": 36.6216869,
+      "longitude": -121.7993168
+    }
+  },
+  "93960": {
+    "coordinates": {
+      "latitude": 36.4176405,
+      "longitude": -121.3998995
+    }
+  },
+  "93962": {
+    "coordinates": {
+      "latitude": 36.6250909,
+      "longitude": -121.6461352
+    }
+  },
+  "94002": {
+    "coordinates": {
+      "latitude": 37.5178022,
+      "longitude": -122.2900288
+    }
+  },
+  "94003": {
+    "coordinates": {
+      "latitude": 37.381144,
+      "longitude": -122.334825
+    }
+  },
+  "94005": {
+    "coordinates": {
+      "latitude": 37.6948419,
+      "longitude": -122.4070834
+    }
+  },
+  "94010": {
+    "coordinates": {
+      "latitude": 37.5685247,
+      "longitude": -122.367428
+    }
+  },
+  "94011": {
+    "coordinates": {
+      "latitude": 37.58,
+      "longitude": -122.37
+    }
+  },
+  "94012": {
+    "coordinates": {
+      "latitude": 37.381144,
+      "longitude": -122.334825
+    }
+  },
+  "94014": {
+    "coordinates": {
+      "latitude": 37.6904558,
+      "longitude": -122.4523855
+    }
+  },
+  "94015": {
+    "coordinates": {
+      "latitude": 37.68000019999999,
+      "longitude": -122.4863492
+    }
+  },
+  "94016": {
+    "coordinates": {
+      "latitude": 37.71,
+      "longitude": -122.45
+    }
+  },
+  "94017": {
+    "coordinates": {
+      "latitude": 37.69,
+      "longitude": -122.47
+    }
+  },
+  "94018": {
+    "coordinates": {
+      "latitude": 37.5017068,
+      "longitude": -122.4688381
+    }
+  },
+  "94019": {
+    "coordinates": {
+      "latitude": 37.4903082,
+      "longitude": -122.4353995
+    }
+  },
+  "94020": {
+    "coordinates": {
+      "latitude": 37.2911153,
+      "longitude": -122.2086579
+    }
+  },
+  "94021": {
+    "coordinates": {
+      "latitude": 37.2704205,
+      "longitude": -122.2767313
+    }
+  },
+  "94022": {
+    "coordinates": {
+      "latitude": 37.3694009,
+      "longitude": -122.1405413
+    }
+  },
+  "94023": {
+    "coordinates": {
+      "latitude": 37.39,
+      "longitude": -122.11
+    }
+  },
+  "94024": {
+    "coordinates": {
+      "latitude": 37.3478257,
+      "longitude": -122.1007867
+    }
+  },
+  "94025": {
+    "coordinates": {
+      "latitude": 37.4484914,
+      "longitude": -122.1802812
+    }
+  },
+  "94026": {
+    "coordinates": {
+      "latitude": 37.4481851,
+      "longitude": -122.1810176
+    }
+  },
+  "94027": {
+    "coordinates": {
+      "latitude": 37.45117949999999,
+      "longitude": -122.2029832
+    }
+  },
+  "94028": {
+    "coordinates": {
+      "latitude": 37.3871184,
+      "longitude": -122.2086579
+    }
+  },
+  "94029": {
+    "coordinates": {
+      "latitude": 37.381144,
+      "longitude": -122.334825
+    }
+  },
+  "94030": {
+    "coordinates": {
+      "latitude": 37.5958949,
+      "longitude": -122.4184108
+    }
+  },
+  "94031": {
+    "coordinates": {
+      "latitude": 37.381144,
+      "longitude": -122.334825
+    }
+  },
+  "94035": {
+    "coordinates": {
+      "latitude": 37.41752,
+      "longitude": -122.0525
+    }
+  },
+  "94037": {
+    "coordinates": {
+      "latitude": 37.5409047,
+      "longitude": -122.5118148
+    }
+  },
+  "94038": {
+    "coordinates": {
+      "latitude": 37.5463543,
+      "longitude": -122.4863492
+    }
+  },
+  "94039": {
+    "coordinates": {
+      "latitude": 37.39,
+      "longitude": -122.08
+    }
+  },
+  "94040": {
+    "coordinates": {
+      "latitude": 37.3785351,
+      "longitude": -122.086585
+    }
+  },
+  "94041": {
+    "coordinates": {
+      "latitude": 37.386812,
+      "longitude": -122.0751549
+    }
+  },
+  "94042": {
+    "coordinates": {
+      "latitude": 37.3931794,
+      "longitude": -122.0778761
+    }
+  },
+  "94043": {
+    "coordinates": {
+      "latitude": 37.4062237,
+      "longitude": -122.0781663
+    }
+  },
+  "94044": {
+    "coordinates": {
+      "latitude": 37.6101767,
+      "longitude": -122.4806894
+    }
+  },
+  "94045": {
+    "coordinates": {
+      "latitude": 37.381144,
+      "longitude": -122.334825
+    }
+  },
+  "94059": {
+    "coordinates": {
+      "latitude": 37.381144,
+      "longitude": -122.334825
+    }
+  },
+  "94060": {
+    "coordinates": {
+      "latitude": 37.2051162,
+      "longitude": -122.3334258
+    }
+  },
+  "94061": {
+    "coordinates": {
+      "latitude": 37.4634447,
+      "longitude": -122.2256803
+    }
+  },
+  "94062": {
+    "coordinates": {
+      "latitude": 37.41089270000001,
+      "longitude": -122.2880726
+    }
+  },
+  "94063": {
+    "coordinates": {
+      "latitude": 37.5021585,
+      "longitude": -122.2086579
+    }
+  },
+  "94064": {
+    "coordinates": {
+      "latitude": 37.48999999999999,
+      "longitude": -122.23
+    }
+  },
+  "94065": {
+    "coordinates": {
+      "latitude": 37.5331558,
+      "longitude": -122.2483726
+    }
+  },
+  "94066": {
+    "coordinates": {
+      "latitude": 37.6210696,
+      "longitude": -122.4297369
+    }
+  },
+  "94067": {
+    "coordinates": {
+      "latitude": 37.381144,
+      "longitude": -122.334825
+    }
+  },
+  "94070": {
+    "coordinates": {
+      "latitude": 37.4975165,
+      "longitude": -122.2710602
+    }
+  },
+  "94071": {
+    "coordinates": {
+      "latitude": 37.381144,
+      "longitude": -122.334825
+    }
+  },
+  "94074": {
+    "coordinates": {
+      "latitude": 37.3195464,
+      "longitude": -122.367428
+    }
+  },
+  "94080": {
+    "coordinates": {
+      "latitude": 37.6531903,
+      "longitude": -122.4184108
+    }
+  },
+  "94083": {
+    "coordinates": {
+      "latitude": 37.65,
+      "longitude": -122.41
+    }
+  },
+  "94085": {
+    "coordinates": {
+      "latitude": 37.3895297,
+      "longitude": -122.0183914
+    }
+  },
+  "94086": {
+    "coordinates": {
+      "latitude": 37.371859,
+      "longitude": -122.0212337
+    }
+  },
+  "94087": {
+    "coordinates": {
+      "latitude": 37.3492097,
+      "longitude": -122.0326019
+    }
+  },
+  "94088": {
+    "coordinates": {
+      "latitude": 37.42,
+      "longitude": -122
+    }
+  },
+  "94089": {
+    "coordinates": {
+      "latitude": 37.4110966,
+      "longitude": -122.0181762
+    }
+  },
+  "94090": {
+    "coordinates": {
+      "latitude": 37.189396,
+      "longitude": -121.705327
+    }
+  },
+  "94096": {
+    "coordinates": {
+      "latitude": 37.381144,
+      "longitude": -122.334825
+    }
+  },
+  "94098": {
+    "coordinates": {
+      "latitude": 37.381144,
+      "longitude": -122.334825
+    }
+  },
+  "94099": {
+    "coordinates": {
+      "latitude": 37.381144,
+      "longitude": -122.334825
+    }
+  },
+  "94101": {
+    "coordinates": {
+      "latitude": 37.784827,
+      "longitude": -122.727802
+    }
+  },
+  "94102": {
+    "coordinates": {
+      "latitude": 37.7786871,
+      "longitude": -122.4212424
+    }
+  },
+  "94103": {
+    "coordinates": {
+      "latitude": 37.7726402,
+      "longitude": -122.4099154
+    }
+  },
+  "94104": {
+    "coordinates": {
+      "latitude": 37.7911148,
+      "longitude": -122.4021273
+    }
+  },
+  "94105": {
+    "coordinates": {
+      "latitude": 37.7890183,
+      "longitude": -122.3915063
+    }
+  },
+  "94106": {
+    "coordinates": {
+      "latitude": 37.784827,
+      "longitude": -122.727802
+    }
+  },
+  "94107": {
+    "coordinates": {
+      "latitude": 37.7618242,
+      "longitude": -122.3985871
+    }
+  },
+  "94108": {
+    "coordinates": {
+      "latitude": 37.7909427,
+      "longitude": -122.4084994
+    }
+  },
+  "94109": {
+    "coordinates": {
+      "latitude": 37.7929789,
+      "longitude": -122.4212424
+    }
+  },
+  "94110": {
+    "coordinates": {
+      "latitude": 37.7485824,
+      "longitude": -122.4184108
+    }
+  },
+  "94111": {
+    "coordinates": {
+      "latitude": 37.79593620000001,
+      "longitude": -122.4000032
+    }
+  },
+  "94112": {
+    "coordinates": {
+      "latitude": 37.72254909999999,
+      "longitude": -122.4410618
+    }
+  },
+  "94114": {
+    "coordinates": {
+      "latitude": 37.7561438,
+      "longitude": -122.4325682
+    }
+  },
+  "94115": {
+    "coordinates": {
+      "latitude": 37.7877522,
+      "longitude": -122.4382307
+    }
+  },
+  "94116": {
+    "coordinates": {
+      "latitude": 37.7432421,
+      "longitude": -122.497668
+    }
+  },
+  "94117": {
+    "coordinates": {
+      "latitude": 37.7717185,
+      "longitude": -122.4438929
+    }
+  },
+  "94118": {
+    "coordinates": {
+      "latitude": 37.7822891,
+      "longitude": -122.463708
+    }
+  },
+  "94119": {
+    "coordinates": {
+      "latitude": 37.7922161,
+      "longitude": -122.3920021
+    }
+  },
+  "94120": {
+    "coordinates": {
+      "latitude": 37.7898327,
+      "longitude": -122.4001644
+    }
+  },
+  "94121": {
+    "coordinates": {
+      "latitude": 37.7813454,
+      "longitude": -122.497668
+    }
+  },
+  "94122": {
+    "coordinates": {
+      "latitude": 37.7597481,
+      "longitude": -122.4750292
+    }
+  },
+  "94123": {
+    "coordinates": {
+      "latitude": 37.8020405,
+      "longitude": -122.4382307
+    }
+  },
+  "94124": {
+    "coordinates": {
+      "latitude": 37.7304167,
+      "longitude": -122.384425
+    }
+  },
+  "94125": {
+    "coordinates": {
+      "latitude": 37.78,
+      "longitude": -122.42
+    }
+  },
+  "94126": {
+    "coordinates": {
+      "latitude": 37.798664,
+      "longitude": -122.3972211
+    }
+  },
+  "94127": {
+    "coordinates": {
+      "latitude": 37.734646,
+      "longitude": -122.463708
+    }
+  },
+  "94128": {
+    "coordinates": {
+      "latitude": 37.6239079,
+      "longitude": -122.3815924
+    }
+  },
+  "94129": {
+    "coordinates": {
+      "latitude": 37.793323,
+      "longitude": -122.4665384
+    }
+  },
+  "94130": {
+    "coordinates": {
+      "latitude": 37.8229361,
+      "longitude": -122.3702611
+    }
+  },
+  "94131": {
+    "coordinates": {
+      "latitude": 37.7401042,
+      "longitude": -122.4382307
+    }
+  },
+  "94132": {
+    "coordinates": {
+      "latitude": 37.7181398,
+      "longitude": -122.4863492
+    }
+  },
+  "94133": {
+    "coordinates": {
+      "latitude": 37.8059887,
+      "longitude": -122.4099154
+    }
+  },
+  "94134": {
+    "coordinates": {
+      "latitude": 37.7202042,
+      "longitude": -122.4099154
+    }
+  },
+  "94135": {
+    "coordinates": {
+      "latitude": 37.784827,
+      "longitude": -122.727802
+    }
+  },
+  "94136": {
+    "coordinates": {
+      "latitude": 37.784827,
+      "longitude": -122.727802
+    }
+  },
+  "94137": {
+    "coordinates": {
+      "latitude": 37.79,
+      "longitude": -122.4
+    }
+  },
+  "94138": {
+    "coordinates": {
+      "latitude": 37.784827,
+      "longitude": -122.727802
+    }
+  },
+  "94139": {
+    "coordinates": {
+      "latitude": 37.78,
+      "longitude": -122.42
+    }
+  },
+  "94140": {
+    "coordinates": {
+      "latitude": 37.7599391,
+      "longitude": -122.4200879
+    }
+  },
+  "94141": {
+    "coordinates": {
+      "latitude": 37.77,
+      "longitude": -122.41
+    }
+  },
+  "94142": {
+    "coordinates": {
+      "latitude": 37.7817297,
+      "longitude": -122.4159407
+    }
+  },
+  "94143": {
+    "coordinates": {
+      "latitude": 37.7642093,
+      "longitude": -122.4571623
+    }
+  },
+  "94144": {
+    "coordinates": {
+      "latitude": 37.78,
+      "longitude": -122.42
+    }
+  },
+  "94145": {
+    "coordinates": {
+      "latitude": 37.79,
+      "longitude": -122.4
+    }
+  },
+  "94146": {
+    "coordinates": {
+      "latitude": 37.78,
+      "longitude": -122.42
+    }
+  },
+  "94147": {
+    "coordinates": {
+      "latitude": 37.78,
+      "longitude": -122.42
+    }
+  },
+  "94150": {
+    "coordinates": {
+      "latitude": 37.784827,
+      "longitude": -122.727802
+    }
+  },
+  "94151": {
+    "coordinates": {
+      "latitude": 37.78,
+      "longitude": -122.42
+    }
+  },
+  "94152": {
+    "coordinates": {
+      "latitude": 37.784827,
+      "longitude": -122.727802
+    }
+  },
+  "94153": {
+    "coordinates": {
+      "latitude": 37.784827,
+      "longitude": -122.727802
+    }
+  },
+  "94154": {
+    "coordinates": {
+      "latitude": 37.784827,
+      "longitude": -122.727802
+    }
+  },
+  "94155": {
+    "coordinates": {
+      "latitude": 37.784827,
+      "longitude": -122.727802
+    }
+  },
+  "94156": {
+    "coordinates": {
+      "latitude": 37.784827,
+      "longitude": -122.727802
+    }
+  },
+  "94157": {
+    "coordinates": {
+      "latitude": 37.784827,
+      "longitude": -122.727802
+    }
+  },
+  "94159": {
+    "coordinates": {
+      "latitude": 37.7794055,
+      "longitude": -122.4494738
+    }
+  },
+  "94160": {
+    "coordinates": {
+      "latitude": 37.78,
+      "longitude": -122.42
+    }
+  },
+  "94161": {
+    "coordinates": {
+      "latitude": 37.78,
+      "longitude": -122.42
+    }
+  },
+  "94162": {
+    "coordinates": {
+      "latitude": 37.784827,
+      "longitude": -122.727802
+    }
+  },
+  "94163": {
+    "coordinates": {
+      "latitude": 37.78,
+      "longitude": -122.42
+    }
+  },
+  "94164": {
+    "coordinates": {
+      "latitude": 37.7897237,
+      "longitude": -122.4216779
+    }
+  },
+  "94165": {
+    "coordinates": {
+      "latitude": 37.784827,
+      "longitude": -122.727802
+    }
+  },
+  "94166": {
+    "coordinates": {
+      "latitude": 37.784827,
+      "longitude": -122.727802
+    }
+  },
+  "94167": {
+    "coordinates": {
+      "latitude": 37.784827,
+      "longitude": -122.727802
+    }
+  },
+  "94168": {
+    "coordinates": {
+      "latitude": 37.784827,
+      "longitude": -122.727802
+    }
+  },
+  "94169": {
+    "coordinates": {
+      "latitude": 37.784827,
+      "longitude": -122.727802
+    }
+  },
+  "94170": {
+    "coordinates": {
+      "latitude": 37.784827,
+      "longitude": -122.727802
+    }
+  },
+  "94171": {
+    "coordinates": {
+      "latitude": 37.784827,
+      "longitude": -122.727802
+    }
+  },
+  "94172": {
+    "coordinates": {
+      "latitude": 37.78,
+      "longitude": -122.42
+    }
+  },
+  "94175": {
+    "coordinates": {
+      "latitude": 37.784827,
+      "longitude": -122.727802
+    }
+  },
+  "94177": {
+    "coordinates": {
+      "latitude": 37.78,
+      "longitude": -122.42
+    }
+  },
+  "94188": {
+    "coordinates": {
+      "latitude": 37.73999999999999,
+      "longitude": -122.38
+    }
+  },
+  "94203": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94204": {
+    "coordinates": {
+      "latitude": 38.6,
+      "longitude": -121.45
+    }
+  },
+  "94205": {
+    "coordinates": {
+      "latitude": 38.4799999,
+      "longitude": -121.44
+    }
+  },
+  "94206": {
+    "coordinates": {
+      "latitude": 38.4799999,
+      "longitude": -121.44
+    }
+  },
+  "94207": {
+    "coordinates": {
+      "latitude": 38.6,
+      "longitude": -121.45
+    }
+  },
+  "94208": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94209": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94211": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94229": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94230": {
+    "coordinates": {
+      "latitude": 38.4799999,
+      "longitude": -121.44
+    }
+  },
+  "94232": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94234": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94235": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94236": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94237": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94239": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94240": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94243": {
+    "coordinates": {
+      "latitude": 38.377411,
+      "longitude": -121.444429
+    }
+  },
+  "94244": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94245": {
+    "coordinates": {
+      "latitude": 38.56,
+      "longitude": -121.48
+    }
+  },
+  "94246": {
+    "coordinates": {
+      "latitude": 38.377411,
+      "longitude": -121.444429
+    }
+  },
+  "94247": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94248": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94249": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94250": {
+    "coordinates": {
+      "latitude": 38.57,
+      "longitude": -121.47
+    }
+  },
+  "94252": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94253": {
+    "coordinates": {
+      "latitude": 38.377411,
+      "longitude": -121.444429
+    }
+  },
+  "94254": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94256": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94257": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94258": {
+    "coordinates": {
+      "latitude": 38.6,
+      "longitude": -121.45
+    }
+  },
+  "94259": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94261": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94262": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94263": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94267": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94268": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94269": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94271": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94273": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94274": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94277": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94278": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94279": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94280": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94282": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94283": {
+    "coordinates": {
+      "latitude": 38.4799999,
+      "longitude": -121.44
+    }
+  },
+  "94284": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94285": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94286": {
+    "coordinates": {
+      "latitude": 38.377411,
+      "longitude": -121.444429
+    }
+  },
+  "94287": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94288": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94289": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94290": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94291": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94293": {
+    "coordinates": {
+      "latitude": 19.1195492,
+      "longitude": -96.10764499999999
+    }
+  },
+  "94294": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94295": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94296": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94297": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94298": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94299": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "94301": {
+    "coordinates": {
+      "latitude": 37.4457966,
+      "longitude": -122.1575745
+    }
+  },
+  "94302": {
+    "coordinates": {
+      "latitude": 37.44,
+      "longitude": -122.14
+    }
+  },
+  "94303": {
+    "coordinates": {
+      "latitude": 37.4530553,
+      "longitude": -122.1178261
+    }
+  },
+  "94304": {
+    "coordinates": {
+      "latitude": 37.3813444,
+      "longitude": -122.1802812
+    }
+  },
+  "94305": {
+    "coordinates": {
+      "latitude": 37.4135757,
+      "longitude": -122.1689284
+    }
+  },
+  "94306": {
+    "coordinates": {
+      "latitude": 37.4177563,
+      "longitude": -122.1235054
+    }
+  },
+  "94307": {
+    "coordinates": {
+      "latitude": 37.381144,
+      "longitude": -122.334825
+    }
+  },
+  "94308": {
+    "coordinates": {
+      "latitude": 37.381144,
+      "longitude": -122.334825
+    }
+  },
+  "94309": {
+    "coordinates": {
+      "latitude": 37.42,
+      "longitude": -122.17
+    }
+  },
+  "94310": {
+    "coordinates": {
+      "latitude": 37.189396,
+      "longitude": -121.705327
+    }
+  },
+  "94401": {
+    "coordinates": {
+      "latitude": 37.5793536,
+      "longitude": -122.3164207
+    }
+  },
+  "94402": {
+    "coordinates": {
+      "latitude": 37.5245965,
+      "longitude": -122.3390936
+    }
+  },
+  "94403": {
+    "coordinates": {
+      "latitude": 37.5349925,
+      "longitude": -122.3050823
+    }
+  },
+  "94404": {
+    "coordinates": {
+      "latitude": 37.5549479,
+      "longitude": -122.2710602
+    }
+  },
+  "94405": {
+    "coordinates": {
+      "latitude": 37.381144,
+      "longitude": -122.334825
+    }
+  },
+  "94406": {
+    "coordinates": {
+      "latitude": 37.381144,
+      "longitude": -122.334825
+    }
+  },
+  "94407": {
+    "coordinates": {
+      "latitude": 37.381144,
+      "longitude": -122.334825
+    }
+  },
+  "94408": {
+    "coordinates": {
+      "latitude": 37.381144,
+      "longitude": -122.334825
+    }
+  },
+  "94409": {
+    "coordinates": {
+      "latitude": 37.381144,
+      "longitude": -122.334825
+    }
+  },
+  "94420": {
+    "coordinates": {
+      "latitude": 37.562385,
+      "longitude": -122.251078
+    }
+  },
+  "94497": {
+    "coordinates": {
+      "latitude": 37.5434184,
+      "longitude": -122.3274035
+    }
+  },
+  "94501": {
+    "coordinates": {
+      "latitude": 37.7712165,
+      "longitude": -122.2824021
+    }
+  },
+  "94502": {
+    "coordinates": {
+      "latitude": 37.7339032,
+      "longitude": -122.2483726
+    }
+  },
+  "94503": {
+    "coordinates": {
+      "latitude": 38.1876611,
+      "longitude": -122.2427
+    }
+  },
+  "94506": {
+    "coordinates": {
+      "latitude": 37.8213111,
+      "longitude": -121.9131761
+    }
+  },
+  "94507": {
+    "coordinates": {
+      "latitude": 37.8541701,
+      "longitude": -122.0098642
+    }
+  },
+  "94508": {
+    "coordinates": {
+      "latitude": 38.5725972,
+      "longitude": -122.4353995
+    }
+  },
+  "94509": {
+    "coordinates": {
+      "latitude": 38.0083802,
+      "longitude": -121.7993168
+    }
+  },
+  "94510": {
+    "coordinates": {
+      "latitude": 38.1153501,
+      "longitude": -122.1064668
+    }
+  },
+  "94511": {
+    "coordinates": {
+      "latitude": 38.0340942,
+      "longitude": -121.6340142
+    }
+  },
+  "94512": {
+    "coordinates": {
+      "latitude": 38.1349416,
+      "longitude": -121.822098
+    }
+  },
+  "94513": {
+    "coordinates": {
+      "latitude": 37.9341399,
+      "longitude": -121.6967438
+    }
+  },
+  "94514": {
+    "coordinates": {
+      "latitude": 37.8076915,
+      "longitude": -121.6397184
+    }
+  },
+  "94515": {
+    "coordinates": {
+      "latitude": 38.6045556,
+      "longitude": -122.6051351
+    }
+  },
+  "94516": {
+    "coordinates": {
+      "latitude": 37.8251445,
+      "longitude": -122.1604131
+    }
+  },
+  "94517": {
+    "coordinates": {
+      "latitude": 37.8793779,
+      "longitude": -121.8790306
+    }
+  },
+  "94518": {
+    "coordinates": {
+      "latitude": 37.9461207,
+      "longitude": -122.0212337
+    }
+  },
+  "94519": {
+    "coordinates": {
+      "latitude": 37.9876914,
+      "longitude": -122.0098642
+    }
+  },
+  "94520": {
+    "coordinates": {
+      "latitude": 38.0349026,
+      "longitude": -122.026918
+    }
+  },
+  "94521": {
+    "coordinates": {
+      "latitude": 37.9538109,
+      "longitude": -121.9643745
+    }
+  },
+  "94522": {
+    "coordinates": {
+      "latitude": 37.989945,
+      "longitude": -122.0399537
+    }
+  },
+  "94523": {
+    "coordinates": {
+      "latitude": 37.9448915,
+      "longitude": -122.0723816
+    }
+  },
+  "94524": {
+    "coordinates": {
+      "latitude": 37.9799999,
+      "longitude": -122.06
+    }
+  },
+  "94525": {
+    "coordinates": {
+      "latitude": 38.0456817,
+      "longitude": -122.2256803
+    }
+  },
+  "94526": {
+    "coordinates": {
+      "latitude": 37.8006948,
+      "longitude": -121.9814354
+    }
+  },
+  "94527": {
+    "coordinates": {
+      "latitude": 37.9799999,
+      "longitude": -122.06
+    }
+  },
+  "94528": {
+    "coordinates": {
+      "latitude": 37.8353026,
+      "longitude": -121.955525
+    }
+  },
+  "94529": {
+    "coordinates": {
+      "latitude": 37.9799999,
+      "longitude": -122.03
+    }
+  },
+  "94530": {
+    "coordinates": {
+      "latitude": 37.9202057,
+      "longitude": -122.2937428
+    }
+  },
+  "94531": {
+    "coordinates": {
+      "latitude": 37.9644542,
+      "longitude": -121.7708337
+    }
+  },
+  "94533": {
+    "coordinates": {
+      "latitude": 38.2493627,
+      "longitude": -122.0399969
+    }
+  },
+  "94534": {
+    "coordinates": {
+      "latitude": 38.2672631,
+      "longitude": -122.1064668
+    }
+  },
+  "94535": {
+    "coordinates": {
+      "latitude": 38.27814619999999,
+      "longitude": -121.9302449
+    }
+  },
+  "94536": {
+    "coordinates": {
+      "latitude": 37.5641425,
+      "longitude": -122.004179
+    }
+  },
+  "94537": {
+    "coordinates": {
+      "latitude": 37.5496876,
+      "longitude": -121.9697367
+    }
+  },
+  "94538": {
+    "coordinates": {
+      "latitude": 37.5042267,
+      "longitude": -121.9643745
+    }
+  },
+  "94539": {
+    "coordinates": {
+      "latitude": 37.5148444,
+      "longitude": -121.9131761
+    }
+  },
+  "94540": {
+    "coordinates": {
+      "latitude": 37.6599999,
+      "longitude": -122.1
+    }
+  },
+  "94541": {
+    "coordinates": {
+      "latitude": 37.6737239,
+      "longitude": -122.1007867
+    }
+  },
+  "94542": {
+    "coordinates": {
+      "latitude": 37.6561165,
+      "longitude": -122.0326019
+    }
+  },
+  "94543": {
+    "coordinates": {
+      "latitude": 37.67,
+      "longitude": -122.08
+    }
+  },
+  "94544": {
+    "coordinates": {
+      "latitude": 37.6270256,
+      "longitude": -122.0496521
+    }
+  },
+  "94545": {
+    "coordinates": {
+      "latitude": 37.6063621,
+      "longitude": -122.1178261
+    }
+  },
+  "94546": {
+    "coordinates": {
+      "latitude": 37.7188649,
+      "longitude": -122.0780632
+    }
+  },
+  "94547": {
+    "coordinates": {
+      "latitude": 38.00674,
+      "longitude": -122.259717
+    }
+  },
+  "94548": {
+    "coordinates": {
+      "latitude": 37.9714216,
+      "longitude": -121.6639577
+    }
+  },
+  "94549": {
+    "coordinates": {
+      "latitude": 37.8929461,
+      "longitude": -122.1178261
+    }
+  },
+  "94550": {
+    "coordinates": {
+      "latitude": 37.6536947,
+      "longitude": -121.6739371
+    }
+  },
+  "94551": {
+    "coordinates": {
+      "latitude": 37.7537708,
+      "longitude": -121.7879244
+    }
+  },
+  "94552": {
+    "coordinates": {
+      "latitude": 37.71045760000001,
+      "longitude": -122.026918
+    }
+  },
+  "94553": {
+    "coordinates": {
+      "latitude": 37.9873593,
+      "longitude": -122.151897
+    }
+  },
+  "94555": {
+    "coordinates": {
+      "latitude": 37.5677679,
+      "longitude": -122.0522177
+    }
+  },
+  "94556": {
+    "coordinates": {
+      "latitude": 37.8357202,
+      "longitude": -122.1178261
+    }
+  },
+  "94557": {
+    "coordinates": {
+      "latitude": 37.63,
+      "longitude": -122.1
+    }
+  },
+  "94558": {
+    "coordinates": {
+      "latitude": 38.3170536,
+      "longitude": -122.3019206
+    }
+  },
+  "94559": {
+    "coordinates": {
+      "latitude": 38.22965,
+      "longitude": -122.3220894
+    }
+  },
+  "94560": {
+    "coordinates": {
+      "latitude": 37.5189256,
+      "longitude": -122.026918
+    }
+  },
+  "94561": {
+    "coordinates": {
+      "latitude": 38.0044162,
+      "longitude": -121.685341
+    }
+  },
+  "94562": {
+    "coordinates": {
+      "latitude": 38.4372868,
+      "longitude": -122.4029586
+    }
+  },
+  "94563": {
+    "coordinates": {
+      "latitude": 37.8912529,
+      "longitude": -122.1859572
+    }
+  },
+  "94564": {
+    "coordinates": {
+      "latitude": 37.9963136,
+      "longitude": -122.2937428
+    }
+  },
+  "94565": {
+    "coordinates": {
+      "latitude": 38.0182853,
+      "longitude": -121.9245556
+    }
+  },
+  "94566": {
+    "coordinates": {
+      "latitude": 37.6436199,
+      "longitude": -121.8676464
+    }
+  },
+  "94567": {
+    "coordinates": {
+      "latitude": 38.6844198,
+      "longitude": -122.4693688
+    }
+  },
+  "94568": {
+    "coordinates": {
+      "latitude": 37.7202463,
+      "longitude": -121.8676464
+    }
+  },
+  "94569": {
+    "coordinates": {
+      "latitude": 38.0403192,
+      "longitude": -122.188795
+    }
+  },
+  "94570": {
+    "coordinates": {
+      "latitude": 37.86,
+      "longitude": -122.12
+    }
+  },
+  "94571": {
+    "coordinates": {
+      "latitude": 38.1494225,
+      "longitude": -121.7423434
+    }
+  },
+  "94572": {
+    "coordinates": {
+      "latitude": 38.02923,
+      "longitude": -122.2483726
+    }
+  },
+  "94573": {
+    "coordinates": {
+      "latitude": 38.4645752,
+      "longitude": -122.4226582
+    }
+  },
+  "94574": {
+    "coordinates": {
+      "latitude": 38.5241378,
+      "longitude": -122.3787597
+    }
+  },
+  "94575": {
+    "coordinates": {
+      "latitude": 37.84,
+      "longitude": -122.13
+    }
+  },
+  "94576": {
+    "coordinates": {
+      "latitude": 38.5600327,
+      "longitude": -122.4835193
+    }
+  },
+  "94577": {
+    "coordinates": {
+      "latitude": 37.7199247,
+      "longitude": -122.1689284
+    }
+  },
+  "94578": {
+    "coordinates": {
+      "latitude": 37.7050703,
+      "longitude": -122.1235054
+    }
+  },
+  "94579": {
+    "coordinates": {
+      "latitude": 37.6851553,
+      "longitude": -122.1575745
+    }
+  },
+  "94580": {
+    "coordinates": {
+      "latitude": 37.6729393,
+      "longitude": -122.1348629
+    }
+  },
+  "94581": {
+    "coordinates": {
+      "latitude": 38.3,
+      "longitude": -122.28
+    }
+  },
+  "94583": {
+    "coordinates": {
+      "latitude": 37.7624642,
+      "longitude": -121.9814354
+    }
+  },
+  "94585": {
+    "coordinates": {
+      "latitude": 38.1705985,
+      "longitude": -121.9245556
+    }
+  },
+  "94586": {
+    "coordinates": {
+      "latitude": 37.5867626,
+      "longitude": -121.8334868
+    }
+  },
+  "94587": {
+    "coordinates": {
+      "latitude": 37.5952304,
+      "longitude": -122.043969
+    }
+  },
+  "94588": {
+    "coordinates": {
+      "latitude": 37.6873908,
+      "longitude": -121.9131761
+    }
+  },
+  "94589": {
+    "coordinates": {
+      "latitude": 38.1457572,
+      "longitude": -122.2710602
+    }
+  },
+  "94590": {
+    "coordinates": {
+      "latitude": 38.1052454,
+      "longitude": -122.2483726
+    }
+  },
+  "94591": {
+    "coordinates": {
+      "latitude": 38.1256242,
+      "longitude": -122.1973081
+    }
+  },
+  "94592": {
+    "coordinates": {
+      "latitude": 38.088795,
+      "longitude": -122.2710602
+    }
+  },
+  "94595": {
+    "coordinates": {
+      "latitude": 37.8655663,
+      "longitude": -122.0666997
+    }
+  },
+  "94596": {
+    "coordinates": {
+      "latitude": 37.8824054,
+      "longitude": -122.026918
+    }
+  },
+  "94597": {
+    "coordinates": {
+      "latitude": 37.9193365,
+      "longitude": -122.0780632
+    }
+  },
+  "94598": {
+    "coordinates": {
+      "latitude": 37.89618249999999,
+      "longitude": -121.9814354
+    }
+  },
+  "94599": {
+    "coordinates": {
+      "latitude": 38.39844600000001,
+      "longitude": -122.373094
+    }
+  },
+  "94601": {
+    "coordinates": {
+      "latitude": 37.7729273,
+      "longitude": -122.2143323
+    }
+  },
+  "94602": {
+    "coordinates": {
+      "latitude": 37.8015517,
+      "longitude": -122.2143323
+    }
+  },
+  "94603": {
+    "coordinates": {
+      "latitude": 37.7355719,
+      "longitude": -122.1802812
+    }
+  },
+  "94604": {
+    "coordinates": {
+      "latitude": 37.8,
+      "longitude": -122.27
+    }
+  },
+  "94605": {
+    "coordinates": {
+      "latitude": 37.7554905,
+      "longitude": -122.1462193
+    }
+  },
+  "94606": {
+    "coordinates": {
+      "latitude": 37.7944092,
+      "longitude": -122.2455364
+    }
+  },
+  "94607": {
+    "coordinates": {
+      "latitude": 37.8134679,
+      "longitude": -122.307917
+    }
+  },
+  "94608": {
+    "coordinates": {
+      "latitude": 37.837959,
+      "longitude": -122.2824021
+    }
+  },
+  "94609": {
+    "coordinates": {
+      "latitude": 37.8321173,
+      "longitude": -122.2625529
+    }
+  },
+  "94610": {
+    "coordinates": {
+      "latitude": 37.8104485,
+      "longitude": -122.2398636
+    }
+  },
+  "94611": {
+    "coordinates": {
+      "latitude": 37.8336281,
+      "longitude": -122.2029832
+    }
+  },
+  "94612": {
+    "coordinates": {
+      "latitude": 37.8113159,
+      "longitude": -122.2682245
+    }
+  },
+  "94613": {
+    "coordinates": {
+      "latitude": 37.7816835,
+      "longitude": -122.1817002
+    }
+  },
+  "94614": {
+    "coordinates": {
+      "latitude": 37.72,
+      "longitude": -122.22
+    }
+  },
+  "94615": {
+    "coordinates": {
+      "latitude": 37.8052928,
+      "longitude": -122.3015389
+    }
+  },
+  "94617": {
+    "coordinates": {
+      "latitude": 37.8,
+      "longitude": -122.27
+    }
+  },
+  "94618": {
+    "coordinates": {
+      "latitude": 37.8438192,
+      "longitude": -122.2398636
+    }
+  },
+  "94619": {
+    "coordinates": {
+      "latitude": 37.7936811,
+      "longitude": -122.1462193
+    }
+  },
+  "94620": {
+    "coordinates": {
+      "latitude": 37.83,
+      "longitude": -122.25
+    }
+  },
+  "94621": {
+    "coordinates": {
+      "latitude": 37.7347438,
+      "longitude": -122.2143323
+    }
+  },
+  "94623": {
+    "coordinates": {
+      "latitude": 37.8046443,
+      "longitude": -122.3008334
+    }
+  },
+  "94624": {
+    "coordinates": {
+      "latitude": 37.75,
+      "longitude": -122.17
+    }
+  },
+  "94625": {
+    "coordinates": {
+      "latitude": 37.803927,
+      "longitude": -122.319655
+    }
+  },
+  "94626": {
+    "coordinates": {
+      "latitude": 37.819314,
+      "longitude": -122.303136
+    }
+  },
+  "94627": {
+    "coordinates": {
+      "latitude": 37.680181,
+      "longitude": -121.921498
+    }
+  },
+  "94643": {
+    "coordinates": {
+      "latitude": 37.680181,
+      "longitude": -121.921498
+    }
+  },
+  "94649": {
+    "coordinates": {
+      "latitude": 37.83,
+      "longitude": -122.2922557
+    }
+  },
+  "94659": {
+    "coordinates": {
+      "latitude": 37.8102522,
+      "longitude": -122.2658041
+    }
+  },
+  "94660": {
+    "coordinates": {
+      "latitude": 37.7954139,
+      "longitude": -122.2685789
+    }
+  },
+  "94661": {
+    "coordinates": {
+      "latitude": 37.83,
+      "longitude": -122.21
+    }
+  },
+  "94662": {
+    "coordinates": {
+      "latitude": 37.84,
+      "longitude": -122.29
+    }
+  },
+  "94666": {
+    "coordinates": {
+      "latitude": 37.8080522,
+      "longitude": -122.2637936
+    }
+  },
+  "94701": {
+    "coordinates": {
+      "latitude": 37.8683209,
+      "longitude": -122.2703955
+    }
+  },
+  "94702": {
+    "coordinates": {
+      "latitude": 37.8680576,
+      "longitude": -122.2852374
+    }
+  },
+  "94703": {
+    "coordinates": {
+      "latitude": 37.85247409999999,
+      "longitude": -122.2738958
+    }
+  },
+  "94704": {
+    "coordinates": {
+      "latitude": 37.86373760000001,
+      "longitude": -122.2682245
+    }
+  },
+  "94705": {
+    "coordinates": {
+      "latitude": 37.8646149,
+      "longitude": -122.2341905
+    }
+  },
+  "94706": {
+    "coordinates": {
+      "latitude": 37.8883952,
+      "longitude": -122.2965778
+    }
+  },
+  "94707": {
+    "coordinates": {
+      "latitude": 37.8983665,
+      "longitude": -122.2795667
+    }
+  },
+  "94708": {
+    "coordinates": {
+      "latitude": 37.9020612,
+      "longitude": -122.259717
+    }
+  },
+  "94709": {
+    "coordinates": {
+      "latitude": 37.8796524,
+      "longitude": -122.2668066
+    }
+  },
+  "94710": {
+    "coordinates": {
+      "latitude": 37.8645848,
+      "longitude": -122.2965778
+    }
+  },
+  "94712": {
+    "coordinates": {
+      "latitude": 37.86990249999999,
+      "longitude": -122.2700128
+    }
+  },
+  "94720": {
+    "coordinates": {
+      "latitude": 37.87015100000001,
+      "longitude": -122.2594606
+    }
+  },
+  "94801": {
+    "coordinates": {
+      "latitude": 37.9429522,
+      "longitude": -122.3900901
+    }
+  },
+  "94802": {
+    "coordinates": {
+      "latitude": 37.94,
+      "longitude": -122.36
+    }
+  },
+  "94803": {
+    "coordinates": {
+      "latitude": 37.9587253,
+      "longitude": -122.2767313
+    }
+  },
+  "94804": {
+    "coordinates": {
+      "latitude": 37.9158152,
+      "longitude": -122.3390936
+    }
+  },
+  "94805": {
+    "coordinates": {
+      "latitude": 37.9383242,
+      "longitude": -122.3277578
+    }
+  },
+  "94806": {
+    "coordinates": {
+      "latitude": 37.9759027,
+      "longitude": -122.3447611
+    }
+  },
+  "94807": {
+    "coordinates": {
+      "latitude": 37.93,
+      "longitude": -122.38
+    }
+  },
+  "94808": {
+    "coordinates": {
+      "latitude": 37.93,
+      "longitude": -122.34
+    }
+  },
+  "94820": {
+    "coordinates": {
+      "latitude": 37.95,
+      "longitude": -122.27
+    }
+  },
+  "94850": {
+    "coordinates": {
+      "latitude": 37.9004296,
+      "longitude": -122.3213808
+    }
+  },
+  "94901": {
+    "coordinates": {
+      "latitude": 37.9650627,
+      "longitude": -122.503327
+    }
+  },
+  "94903": {
+    "coordinates": {
+      "latitude": 38.0270044,
+      "longitude": -122.5485873
+    }
+  },
+  "94904": {
+    "coordinates": {
+      "latitude": 37.941063,
+      "longitude": -122.5655549
+    }
+  },
+  "94912": {
+    "coordinates": {
+      "latitude": 37.96,
+      "longitude": -122.51
+    }
+  },
+  "94913": {
+    "coordinates": {
+      "latitude": 38.02,
+      "longitude": -122.55
+    }
+  },
+  "94914": {
+    "coordinates": {
+      "latitude": 37.95,
+      "longitude": -122.56
+    }
+  },
+  "94915": {
+    "coordinates": {
+      "latitude": 38.02,
+      "longitude": -122.55
+    }
+  },
+  "94920": {
+    "coordinates": {
+      "latitude": 37.8839827,
+      "longitude": -122.4580469
+    }
+  },
+  "94922": {
+    "coordinates": {
+      "latitude": 38.3412889,
+      "longitude": -122.9494009
+    }
+  },
+  "94923": {
+    "coordinates": {
+      "latitude": 38.3251691,
+      "longitude": -123.0451347
+    }
+  },
+  "94924": {
+    "coordinates": {
+      "latitude": 37.9588807,
+      "longitude": -122.7068429
+    }
+  },
+  "94925": {
+    "coordinates": {
+      "latitude": 37.920558,
+      "longitude": -122.5089856
+    }
+  },
+  "94926": {
+    "coordinates": {
+      "latitude": 38.33,
+      "longitude": -122.71
+    }
+  },
+  "94927": {
+    "coordinates": {
+      "latitude": 38.34,
+      "longitude": -122.7
+    }
+  },
+  "94928": {
+    "coordinates": {
+      "latitude": 38.3437823,
+      "longitude": -122.7011951
+    }
+  },
+  "94929": {
+    "coordinates": {
+      "latitude": 38.2573286,
+      "longitude": -122.9691183
+    }
+  },
+  "94930": {
+    "coordinates": {
+      "latitude": 37.9873145,
+      "longitude": -122.5891656
+    }
+  },
+  "94931": {
+    "coordinates": {
+      "latitude": 38.3272883,
+      "longitude": -122.7237843
+    }
+  },
+  "94933": {
+    "coordinates": {
+      "latitude": 38.0008669,
+      "longitude": -122.6786008
+    }
+  },
+  "94937": {
+    "coordinates": {
+      "latitude": 38.1284731,
+      "longitude": -122.9212265
+    }
+  },
+  "94938": {
+    "coordinates": {
+      "latitude": 38.0152314,
+      "longitude": -122.7237843
+    }
+  },
+  "94939": {
+    "coordinates": {
+      "latitude": 37.938818,
+      "longitude": -122.5344456
+    }
+  },
+  "94940": {
+    "coordinates": {
+      "latitude": 38.1745272,
+      "longitude": -122.8648538
+    }
+  },
+  "94941": {
+    "coordinates": {
+      "latitude": 37.9060624,
+      "longitude": -122.5712101
+    }
+  },
+  "94942": {
+    "coordinates": {
+      "latitude": 37.9099999,
+      "longitude": -122.54
+    }
+  },
+  "94945": {
+    "coordinates": {
+      "latitude": 38.1218145,
+      "longitude": -122.5485873
+    }
+  },
+  "94946": {
+    "coordinates": {
+      "latitude": 38.0607149,
+      "longitude": -122.6842498
+    }
+  },
+  "94947": {
+    "coordinates": {
+      "latitude": 38.12457310000001,
+      "longitude": -122.6616518
+    }
+  },
+  "94948": {
+    "coordinates": {
+      "latitude": 38.1,
+      "longitude": -122.57
+    }
+  },
+  "94949": {
+    "coordinates": {
+      "latitude": 38.0599857,
+      "longitude": -122.503327
+    }
+  },
+  "94950": {
+    "coordinates": {
+      "latitude": 38.0537449,
+      "longitude": -122.8013968
+    }
+  },
+  "94951": {
+    "coordinates": {
+      "latitude": 38.3236587,
+      "longitude": -122.6447001
+    }
+  },
+  "94952": {
+    "coordinates": {
+      "latitude": 38.235501,
+      "longitude": -122.6420207
+    }
+  },
+  "94953": {
+    "coordinates": {
+      "latitude": 38.32,
+      "longitude": -122.64
+    }
+  },
+  "94954": {
+    "coordinates": {
+      "latitude": 38.2473117,
+      "longitude": -122.5712101
+    }
+  },
+  "94955": {
+    "coordinates": {
+      "latitude": 38.2299999,
+      "longitude": -122.64
+    }
+  },
+  "94956": {
+    "coordinates": {
+      "latitude": 38.0373567,
+      "longitude": -122.8197329
+    }
+  },
+  "94957": {
+    "coordinates": {
+      "latitude": 37.9633054,
+      "longitude": -122.5627272
+    }
+  },
+  "94960": {
+    "coordinates": {
+      "latitude": 37.9885355,
+      "longitude": -122.5655549
+    }
+  },
+  "94963": {
+    "coordinates": {
+      "latitude": 38.0046478,
+      "longitude": -122.6588267
+    }
+  },
+  "94964": {
+    "coordinates": {
+      "latitude": 37.94018,
+      "longitude": -122.4877642
+    }
+  },
+  "94965": {
+    "coordinates": {
+      "latitude": 37.8444843,
+      "longitude": -122.5089856
+    }
+  },
+  "94966": {
+    "coordinates": {
+      "latitude": 37.86,
+      "longitude": -122.48
+    }
+  },
+  "94970": {
+    "coordinates": {
+      "latitude": 37.9105306,
+      "longitude": -122.6333973
+    }
+  },
+  "94971": {
+    "coordinates": {
+      "latitude": 38.2547479,
+      "longitude": -122.9099545
+    }
+  },
+  "94972": {
+    "coordinates": {
+      "latitude": 38.2971176,
+      "longitude": -122.9550349
+    }
+  },
+  "94973": {
+    "coordinates": {
+      "latitude": 38.0051761,
+      "longitude": -122.6418745
+    }
+  },
+  "94974": {
+    "coordinates": {
+      "latitude": 37.96,
+      "longitude": -122.49
+    }
+  },
+  "94975": {
+    "coordinates": {
+      "latitude": 38.32,
+      "longitude": -122.64
+    }
+  },
+  "94976": {
+    "coordinates": {
+      "latitude": 37.93,
+      "longitude": -122.53
+    }
+  },
+  "94977": {
+    "coordinates": {
+      "latitude": 37.94,
+      "longitude": -122.51
+    }
+  },
+  "94978": {
+    "coordinates": {
+      "latitude": 37.98999999999999,
+      "longitude": -122.59
+    }
+  },
+  "94979": {
+    "coordinates": {
+      "latitude": 37.9703863,
+      "longitude": -122.5602872
+    }
+  },
+  "94991": {
+    "coordinates": {
+      "latitude": 37.970726,
+      "longitude": -122.524012
+    }
+  },
+  "94998": {
+    "coordinates": {
+      "latitude": 38.1,
+      "longitude": -122.57
+    }
+  },
+  "94999": {
+    "coordinates": {
+      "latitude": 38.2719304,
+      "longitude": -122.662005
+    }
+  },
+  "95001": {
+    "coordinates": {
+      "latitude": 36.9759591,
+      "longitude": -121.9007682
+    }
+  },
+  "95002": {
+    "coordinates": {
+      "latitude": 37.4268706,
+      "longitude": -121.9721944
+    }
+  },
+  "95003": {
+    "coordinates": {
+      "latitude": 36.9771465,
+      "longitude": -121.8994154
+    }
+  },
+  "95004": {
+    "coordinates": {
+      "latitude": 36.8825441,
+      "longitude": -121.6397184
+    }
+  },
+  "95005": {
+    "coordinates": {
+      "latitude": 37.0945364,
+      "longitude": -122.0951062
+    }
+  },
+  "95006": {
+    "coordinates": {
+      "latitude": 37.1833232,
+      "longitude": -122.151897
+    }
+  },
+  "95007": {
+    "coordinates": {
+      "latitude": 37.109485,
+      "longitude": -122.1114366
+    }
+  },
+  "95008": {
+    "coordinates": {
+      "latitude": 37.2770029,
+      "longitude": -121.9529992
+    }
+  },
+  "95009": {
+    "coordinates": {
+      "latitude": 37.29,
+      "longitude": -121.95
+    }
+  },
+  "95010": {
+    "coordinates": {
+      "latitude": 36.9764598,
+      "longitude": -121.9501551
+    }
+  },
+  "95011": {
+    "coordinates": {
+      "latitude": 37.29,
+      "longitude": -121.96
+    }
+  },
+  "95012": {
+    "coordinates": {
+      "latitude": 36.7646209,
+      "longitude": -121.7594384
+    }
+  },
+  "95013": {
+    "coordinates": {
+      "latitude": 37.2181037,
+      "longitude": -121.7352197
+    }
+  },
+  "95014": {
+    "coordinates": {
+      "latitude": 37.31317,
+      "longitude": -122.0723816
+    }
+  },
+  "95015": {
+    "coordinates": {
+      "latitude": 37.32,
+      "longitude": -122.03
+    }
+  },
+  "95017": {
+    "coordinates": {
+      "latitude": 37.0918582,
+      "longitude": -122.2313539
+    }
+  },
+  "95018": {
+    "coordinates": {
+      "latitude": 37.0435289,
+      "longitude": -122.0723816
+    }
+  },
+  "95019": {
+    "coordinates": {
+      "latitude": 36.9355718,
+      "longitude": -121.7793794
+    }
+  },
+  "95020": {
+    "coordinates": {
+      "latitude": 37.0127518,
+      "longitude": -121.5598345
+    }
+  },
+  "95021": {
+    "coordinates": {
+      "latitude": 37.01,
+      "longitude": -121.57
+    }
+  },
+  "95022": {
+    "coordinates": {
+      "latitude": 37.32477,
+      "longitude": -122.184276
+    }
+  },
+  "95023": {
+    "coordinates": {
+      "latitude": 36.9119865,
+      "longitude": -121.3084088
+    }
+  },
+  "95024": {
+    "coordinates": {
+      "latitude": 36.85,
+      "longitude": -121.4
+    }
+  },
+  "95026": {
+    "coordinates": {
+      "latitude": 37.1599999,
+      "longitude": -121.98
+    }
+  },
+  "95030": {
+    "coordinates": {
+      "latitude": 37.22823169999999,
+      "longitude": -121.9871217
+    }
+  },
+  "95031": {
+    "coordinates": {
+      "latitude": 37.1599999,
+      "longitude": -121.97
+    }
+  },
+  "95032": {
+    "coordinates": {
+      "latitude": 37.2260616,
+      "longitude": -121.9302449
+    }
+  },
+  "95033": {
+    "coordinates": {
+      "latitude": 37.16110400000001,
+      "longitude": -121.9700618
+    }
+  },
+  "95035": {
+    "coordinates": {
+      "latitude": 37.4323716,
+      "longitude": -121.8993526
+    }
+  },
+  "95036": {
+    "coordinates": {
+      "latitude": 37.43,
+      "longitude": -121.91
+    }
+  },
+  "95037": {
+    "coordinates": {
+      "latitude": 37.2187714,
+      "longitude": -121.5826642
+    }
+  },
+  "95038": {
+    "coordinates": {
+      "latitude": 37.13,
+      "longitude": -121.65
+    }
+  },
+  "95039": {
+    "coordinates": {
+      "latitude": 36.8225884,
+      "longitude": -121.7765309
+    }
+  },
+  "95041": {
+    "coordinates": {
+      "latitude": 37.0510751,
+      "longitude": -122.0584474
+    }
+  },
+  "95042": {
+    "coordinates": {
+      "latitude": 37.18,
+      "longitude": -121.82
+    }
+  },
+  "95043": {
+    "coordinates": {
+      "latitude": 36.5501406,
+      "longitude": -120.9417368
+    }
+  },
+  "95044": {
+    "coordinates": {
+      "latitude": 37.1582811,
+      "longitude": -121.9864638
+    }
+  },
+  "95045": {
+    "coordinates": {
+      "latitude": 36.8322484,
+      "longitude": -121.5141615
+    }
+  },
+  "95046": {
+    "coordinates": {
+      "latitude": 37.0964953,
+      "longitude": -121.57125
+    }
+  },
+  "95050": {
+    "coordinates": {
+      "latitude": 37.3539663,
+      "longitude": -121.9529992
+    }
+  },
+  "95051": {
+    "coordinates": {
+      "latitude": 37.3598283,
+      "longitude": -121.9814354
+    }
+  },
+  "95052": {
+    "coordinates": {
+      "latitude": 37.35,
+      "longitude": -121.96
+    }
+  },
+  "95053": {
+    "coordinates": {
+      "latitude": 37.348667,
+      "longitude": -121.936645
+    }
+  },
+  "95054": {
+    "coordinates": {
+      "latitude": 37.3986039,
+      "longitude": -121.9643745
+    }
+  },
+  "95055": {
+    "coordinates": {
+      "latitude": 37.35,
+      "longitude": -121.98
+    }
+  },
+  "95056": {
+    "coordinates": {
+      "latitude": 37.4,
+      "longitude": -121.96
+    }
+  },
+  "95060": {
+    "coordinates": {
+      "latitude": 37.0105307,
+      "longitude": -122.1178261
+    }
+  },
+  "95061": {
+    "coordinates": {
+      "latitude": 37.06,
+      "longitude": -122.16
+    }
+  },
+  "95062": {
+    "coordinates": {
+      "latitude": 36.9677899,
+      "longitude": -121.9871217
+    }
+  },
+  "95063": {
+    "coordinates": {
+      "latitude": 36.9799999,
+      "longitude": -122.01
+    }
+  },
+  "95064": {
+    "coordinates": {
+      "latitude": 36.9923139,
+      "longitude": -122.0581762
+    }
+  },
+  "95065": {
+    "coordinates": {
+      "latitude": 37.0353977,
+      "longitude": -121.9871217
+    }
+  },
+  "95066": {
+    "coordinates": {
+      "latitude": 37.0702838,
+      "longitude": -122.0155491
+    }
+  },
+  "95067": {
+    "coordinates": {
+      "latitude": 37.05,
+      "longitude": -122.01
+    }
+  },
+  "95070": {
+    "coordinates": {
+      "latitude": 37.2638319,
+      "longitude": -122.023004
+    }
+  },
+  "95071": {
+    "coordinates": {
+      "latitude": 37.26,
+      "longitude": -122.02
+    }
+  },
+  "95073": {
+    "coordinates": {
+      "latitude": 37.0459268,
+      "longitude": -121.9359339
+    }
+  },
+  "95075": {
+    "coordinates": {
+      "latitude": 36.7770944,
+      "longitude": -121.1366715
+    }
+  },
+  "95076": {
+    "coordinates": {
+      "latitude": 36.9199564,
+      "longitude": -121.7423434
+    }
+  },
+  "95077": {
+    "coordinates": {
+      "latitude": 36.9099999,
+      "longitude": -121.76
+    }
+  },
+  "95101": {
+    "coordinates": {
+      "latitude": 37.3904943,
+      "longitude": -121.8854337
+    }
+  },
+  "95102": {
+    "coordinates": {
+      "latitude": 37.189396,
+      "longitude": -121.705327
+    }
+  },
+  "95103": {
+    "coordinates": {
+      "latitude": 37.34,
+      "longitude": -121.89
+    }
+  },
+  "95106": {
+    "coordinates": {
+      "latitude": 37.34,
+      "longitude": -121.89
+    }
+  },
+  "95108": {
+    "coordinates": {
+      "latitude": 37.34,
+      "longitude": -121.89
+    }
+  },
+  "95109": {
+    "coordinates": {
+      "latitude": 37.34,
+      "longitude": -121.89
+    }
+  },
+  "95110": {
+    "coordinates": {
+      "latitude": 37.354611,
+      "longitude": -121.918866
+    }
+  },
+  "95111": {
+    "coordinates": {
+      "latitude": 37.28566319999999,
+      "longitude": -121.8277925
+    }
+  },
+  "95112": {
+    "coordinates": {
+      "latitude": 37.3456227,
+      "longitude": -121.8847222
+    }
+  },
+  "95113": {
+    "coordinates": {
+      "latitude": 37.3326639,
+      "longitude": -121.8918364
+    }
+  },
+  "95114": {
+    "coordinates": {
+      "latitude": 37.189396,
+      "longitude": -121.705327
+    }
+  },
+  "95115": {
+    "coordinates": {
+      "latitude": 37.34,
+      "longitude": -121.89
+    }
+  },
+  "95116": {
+    "coordinates": {
+      "latitude": 37.3558627,
+      "longitude": -121.8505679
+    }
+  },
+  "95117": {
+    "coordinates": {
+      "latitude": 37.3120731,
+      "longitude": -121.9643745
+    }
+  },
+  "95118": {
+    "coordinates": {
+      "latitude": 37.2589827,
+      "longitude": -121.8847222
+    }
+  },
+  "95119": {
+    "coordinates": {
+      "latitude": 37.2318159,
+      "longitude": -121.7822278
+    }
+  },
+  "95120": {
+    "coordinates": {
+      "latitude": 37.1696999,
+      "longitude": -121.8448745
+    }
+  },
+  "95121": {
+    "coordinates": {
+      "latitude": 37.302108,
+      "longitude": -121.8050125
+    }
+  },
+  "95122": {
+    "coordinates": {
+      "latitude": 37.3304014,
+      "longitude": -121.8391808
+    }
+  },
+  "95123": {
+    "coordinates": {
+      "latitude": 37.2374847,
+      "longitude": -121.8277925
+    }
+  },
+  "95124": {
+    "coordinates": {
+      "latitude": 37.2583724,
+      "longitude": -121.918866
+    }
+  },
+  "95125": {
+    "coordinates": {
+      "latitude": 37.2909813,
+      "longitude": -121.8904136
+    }
+  },
+  "95126": {
+    "coordinates": {
+      "latitude": 37.3290122,
+      "longitude": -121.9160211
+    }
+  },
+  "95127": {
+    "coordinates": {
+      "latitude": 37.373498,
+      "longitude": -121.7594384
+    }
+  },
+  "95128": {
+    "coordinates": {
+      "latitude": 37.3189149,
+      "longitude": -121.9416226
+    }
+  },
+  "95129": {
+    "coordinates": {
+      "latitude": 37.3052272,
+      "longitude": -121.9871217
+    }
+  },
+  "95130": {
+    "coordinates": {
+      "latitude": 37.2876164,
+      "longitude": -121.9857002
+    }
+  },
+  "95131": {
+    "coordinates": {
+      "latitude": 37.3902956,
+      "longitude": -121.8961047
+    }
+  },
+  "95132": {
+    "coordinates": {
+      "latitude": 37.4010609,
+      "longitude": -121.8643855
+    }
+  },
+  "95133": {
+    "coordinates": {
+      "latitude": 37.3716914,
+      "longitude": -121.8619539
+    }
+  },
+  "95134": {
+    "coordinates": {
+      "latitude": 37.4308503,
+      "longitude": -121.9529992
+    }
+  },
+  "95135": {
+    "coordinates": {
+      "latitude": 37.2751505,
+      "longitude": -121.685341
+    }
+  },
+  "95136": {
+    "coordinates": {
+      "latitude": 37.2692142,
+      "longitude": -121.8505679
+    }
+  },
+  "95137": {
+    "coordinates": {
+      "latitude": 37.189396,
+      "longitude": -121.705327
+    }
+  },
+  "95138": {
+    "coordinates": {
+      "latitude": 37.2422863,
+      "longitude": -121.7309452
+    }
+  },
+  "95139": {
+    "coordinates": {
+      "latitude": 37.2257107,
+      "longitude": -121.7622874
+    }
+  },
+  "95140": {
+    "coordinates": {
+      "latitude": 37.385095,
+      "longitude": -121.6397184
+    }
+  },
+  "95141": {
+    "coordinates": {
+      "latitude": 37.1676857,
+      "longitude": -121.7708337
+    }
+  },
+  "95142": {
+    "coordinates": {
+      "latitude": 37.189396,
+      "longitude": -121.705327
+    }
+  },
+  "95148": {
+    "coordinates": {
+      "latitude": 37.3315827,
+      "longitude": -121.7708337
+    }
+  },
+  "95150": {
+    "coordinates": {
+      "latitude": 37.39,
+      "longitude": -121.9
+    }
+  },
+  "95151": {
+    "coordinates": {
+      "latitude": 37.322286,
+      "longitude": -121.825862
+    }
+  },
+  "95152": {
+    "coordinates": {
+      "latitude": 37.4,
+      "longitude": -121.85
+    }
+  },
+  "95153": {
+    "coordinates": {
+      "latitude": 37.25,
+      "longitude": -121.85
+    }
+  },
+  "95154": {
+    "coordinates": {
+      "latitude": 37.26,
+      "longitude": -121.91
+    }
+  },
+  "95155": {
+    "coordinates": {
+      "latitude": 37.31,
+      "longitude": -121.9
+    }
+  },
+  "95156": {
+    "coordinates": {
+      "latitude": 37.36,
+      "longitude": -121.84
+    }
+  },
+  "95157": {
+    "coordinates": {
+      "latitude": 37.2999301,
+      "longitude": -121.9799112
+    }
+  },
+  "95158": {
+    "coordinates": {
+      "latitude": 37.26,
+      "longitude": -121.88
+    }
+  },
+  "95159": {
+    "coordinates": {
+      "latitude": 37.32,
+      "longitude": -121.93
+    }
+  },
+  "95160": {
+    "coordinates": {
+      "latitude": 37.22,
+      "longitude": -121.86
+    }
+  },
+  "95161": {
+    "coordinates": {
+      "latitude": 37.39,
+      "longitude": -121.89
+    }
+  },
+  "95164": {
+    "coordinates": {
+      "latitude": 37.39,
+      "longitude": -121.92
+    }
+  },
+  "95170": {
+    "coordinates": {
+      "latitude": 37.3099438,
+      "longitude": -122.0098896
+    }
+  },
+  "95171": {
+    "coordinates": {
+      "latitude": 37.189396,
+      "longitude": -121.705327
+    }
+  },
+  "95172": {
+    "coordinates": {
+      "latitude": 37.33,
+      "longitude": -121.88
+    }
+  },
+  "95173": {
+    "coordinates": {
+      "latitude": 37.34,
+      "longitude": -121.89
+    }
+  },
+  "95190": {
+    "coordinates": {
+      "latitude": 37.3757929,
+      "longitude": -121.9003728
+    }
+  },
+  "95191": {
+    "coordinates": {
+      "latitude": 37.3338976,
+      "longitude": -121.9227776
+    }
+  },
+  "95192": {
+    "coordinates": {
+      "latitude": 37.34,
+      "longitude": -121.88
+    }
+  },
+  "95193": {
+    "coordinates": {
+      "latitude": 37.23999999999999,
+      "longitude": -121.83
+    }
+  },
+  "95194": {
+    "coordinates": {
+      "latitude": 37.39,
+      "longitude": -121.89
+    }
+  },
+  "95196": {
+    "coordinates": {
+      "latitude": 37.3317515,
+      "longitude": -121.8978831
+    }
+  },
+  "95201": {
+    "coordinates": {
+      "latitude": 37.96,
+      "longitude": -121.29
+    }
+  },
+  "95202": {
+    "coordinates": {
+      "latitude": 37.9573836,
+      "longitude": -121.2883857
+    }
+  },
+  "95203": {
+    "coordinates": {
+      "latitude": 37.9536006,
+      "longitude": -121.3255688
+    }
+  },
+  "95204": {
+    "coordinates": {
+      "latitude": 37.9727529,
+      "longitude": -121.3255688
+    }
+  },
+  "95205": {
+    "coordinates": {
+      "latitude": 37.9642589,
+      "longitude": -121.2569138
+    }
+  },
+  "95206": {
+    "coordinates": {
+      "latitude": 37.9009213,
+      "longitude": -121.422761
+    }
+  },
+  "95207": {
+    "coordinates": {
+      "latitude": 37.9983748,
+      "longitude": -121.3198491
+    }
+  },
+  "95208": {
+    "coordinates": {
+      "latitude": 37.9923622,
+      "longitude": -121.2844521
+    }
+  },
+  "95209": {
+    "coordinates": {
+      "latitude": 38.0521138,
+      "longitude": -121.3484448
+    }
+  },
+  "95210": {
+    "coordinates": {
+      "latitude": 38.0434058,
+      "longitude": -121.2969674
+    }
+  },
+  "95211": {
+    "coordinates": {
+      "latitude": 37.9794321,
+      "longitude": -121.3141847
+    }
+  },
+  "95212": {
+    "coordinates": {
+      "latitude": 38.0445015,
+      "longitude": -121.2282958
+    }
+  },
+  "95213": {
+    "coordinates": {
+      "latitude": 37.90561090000001,
+      "longitude": -121.2261491
+    }
+  },
+  "95215": {
+    "coordinates": {
+      "latitude": 37.9434927,
+      "longitude": -121.1481284
+    }
+  },
+  "95219": {
+    "coordinates": {
+      "latitude": 38.0268596,
+      "longitude": -121.5141615
+    }
+  },
+  "95220": {
+    "coordinates": {
+      "latitude": 38.1845539,
+      "longitude": -121.2397438
+    }
+  },
+  "95221": {
+    "coordinates": {
+      "latitude": 38.0777407,
+      "longitude": -120.5534541
+    }
+  },
+  "95222": {
+    "coordinates": {
+      "latitude": 38.064958,
+      "longitude": -120.5969758
+    }
+  },
+  "95223": {
+    "coordinates": {
+      "latitude": 38.4660573,
+      "longitude": -119.9277947
+    }
+  },
+  "95224": {
+    "coordinates": {
+      "latitude": 38.2272338,
+      "longitude": -120.3147208
+    }
+  },
+  "95225": {
+    "coordinates": {
+      "latitude": 38.18328169999999,
+      "longitude": -120.8897471
+    }
+  },
+  "95226": {
+    "coordinates": {
+      "latitude": 38.2189869,
+      "longitude": -120.844152
+    }
+  },
+  "95227": {
+    "coordinates": {
+      "latitude": 38.2148814,
+      "longitude": -121.0306432
+    }
+  },
+  "95228": {
+    "coordinates": {
+      "latitude": 37.9616017,
+      "longitude": -120.6890055
+    }
+  },
+  "95229": {
+    "coordinates": {
+      "latitude": 38.09,
+      "longitude": -120.47
+    }
+  },
+  "95230": {
+    "coordinates": {
+      "latitude": 37.9728082,
+      "longitude": -120.8498944
+    }
+  },
+  "95231": {
+    "coordinates": {
+      "latitude": 37.8774675,
+      "longitude": -121.2912463
+    }
+  },
+  "95232": {
+    "coordinates": {
+      "latitude": 38.3590703,
+      "longitude": -120.5912217
+    }
+  },
+  "95233": {
+    "coordinates": {
+      "latitude": 38.1915556,
+      "longitude": -120.3653085
+    }
+  },
+  "95234": {
+    "coordinates": {
+      "latitude": 37.9267281,
+      "longitude": -121.4310618
+    }
+  },
+  "95236": {
+    "coordinates": {
+      "latitude": 38.0728788,
+      "longitude": -121.03351
+    }
+  },
+  "95237": {
+    "coordinates": {
+      "latitude": 38.160627,
+      "longitude": -121.1424001
+    }
+  },
+  "95240": {
+    "coordinates": {
+      "latitude": 38.1484821,
+      "longitude": -121.1022942
+    }
+  },
+  "95241": {
+    "coordinates": {
+      "latitude": 38.13,
+      "longitude": -121.27
+    }
+  },
+  "95242": {
+    "coordinates": {
+      "latitude": 38.1304288,
+      "longitude": -121.422761
+    }
+  },
+  "95245": {
+    "coordinates": {
+      "latitude": 38.3084205,
+      "longitude": -120.5509358
+    }
+  },
+  "95246": {
+    "coordinates": {
+      "latitude": 38.2449553,
+      "longitude": -120.5048792
+    }
+  },
+  "95247": {
+    "coordinates": {
+      "latitude": 38.1561084,
+      "longitude": -120.4127161
+    }
+  },
+  "95248": {
+    "coordinates": {
+      "latitude": 38.327125,
+      "longitude": -120.5149555
+    }
+  },
+  "95249": {
+    "coordinates": {
+      "latitude": 38.2052914,
+      "longitude": -120.6429991
+    }
+  },
+  "95250": {
+    "coordinates": {
+      "latitude": 38.256839,
+      "longitude": -120.38102
+    }
+  },
+  "95251": {
+    "coordinates": {
+      "latitude": 38.0981926,
+      "longitude": -120.447285
+    }
+  },
+  "95252": {
+    "coordinates": {
+      "latitude": 38.1388264,
+      "longitude": -120.8728615
+    }
+  },
+  "95253": {
+    "coordinates": {
+      "latitude": 38.137643,
+      "longitude": -121.2065426
+    }
+  },
+  "95254": {
+    "coordinates": {
+      "latitude": 38.2016201,
+      "longitude": -120.9532123
+    }
+  },
+  "95255": {
+    "coordinates": {
+      "latitude": 38.4496949,
+      "longitude": -120.4588059
+    }
+  },
+  "95257": {
+    "coordinates": {
+      "latitude": 38.3668576,
+      "longitude": -120.447285
+    }
+  },
+  "95258": {
+    "coordinates": {
+      "latitude": 38.1673741,
+      "longitude": -121.3141291
+    }
+  },
+  "95267": {
+    "coordinates": {
+      "latitude": 38,
+      "longitude": -121.32
+    }
+  },
+  "95269": {
+    "coordinates": {
+      "latitude": 38.02,
+      "longitude": -121.32
+    }
+  },
+  "95290": {
+    "coordinates": {
+      "latitude": 37.953473,
+      "longitude": -121.285257
+    }
+  },
+  "95296": {
+    "coordinates": {
+      "latitude": 37.72,
+      "longitude": -121.38
+    }
+  },
+  "95297": {
+    "coordinates": {
+      "latitude": 38,
+      "longitude": -121.32
+    }
+  },
+  "95298": {
+    "coordinates": {
+      "latitude": 37.889849,
+      "longitude": -121.253872
+    }
+  },
+  "95301": {
+    "coordinates": {
+      "latitude": 37.3178131,
+      "longitude": -120.6429991
+    }
+  },
+  "95303": {
+    "coordinates": {
+      "latitude": 37.4727467,
+      "longitude": -120.6775054
+    }
+  },
+  "95304": {
+    "coordinates": {
+      "latitude": 37.6841772,
+      "longitude": -121.3770336
+    }
+  },
+  "95305": {
+    "coordinates": {
+      "latitude": 37.8245371,
+      "longitude": -120.2527152
+    }
+  },
+  "95306": {
+    "coordinates": {
+      "latitude": 37.4224249,
+      "longitude": -120.1358346
+    }
+  },
+  "95307": {
+    "coordinates": {
+      "latitude": 37.5350396,
+      "longitude": -120.9646866
+    }
+  },
+  "95309": {
+    "coordinates": {
+      "latitude": 37.8696699,
+      "longitude": -120.4170377
+    }
+  },
+  "95310": {
+    "coordinates": {
+      "latitude": 38.079431,
+      "longitude": -120.378138
+    }
+  },
+  "95311": {
+    "coordinates": {
+      "latitude": 37.7071559,
+      "longitude": -120.0896313
+    }
+  },
+  "95312": {
+    "coordinates": {
+      "latitude": 37.42054,
+      "longitude": -120.6663638
+    }
+  },
+  "95313": {
+    "coordinates": {
+      "latitude": 37.4121145,
+      "longitude": -121.0220422
+    }
+  },
+  "95314": {
+    "coordinates": {
+      "latitude": 38.033541,
+      "longitude": -119.92502
+    }
+  },
+  "95315": {
+    "coordinates": {
+      "latitude": 37.4269945,
+      "longitude": -120.769476
+    }
+  },
+  "95316": {
+    "coordinates": {
+      "latitude": 37.5371999,
+      "longitude": -120.6890055
+    }
+  },
+  "95317": {
+    "coordinates": {
+      "latitude": 37.1302486,
+      "longitude": -120.5163949
+    }
+  },
+  "95318": {
+    "coordinates": {
+      "latitude": 37.6616228,
+      "longitude": -119.8005027
+    }
+  },
+  "95319": {
+    "coordinates": {
+      "latitude": 37.6378847,
+      "longitude": -120.9006674
+    }
+  },
+  "95320": {
+    "coordinates": {
+      "latitude": 37.8300406,
+      "longitude": -121.0105733
+    }
+  },
+  "95321": {
+    "coordinates": {
+      "latitude": 37.8492572,
+      "longitude": -119.9277947
+    }
+  },
+  "95322": {
+    "coordinates": {
+      "latitude": 37.2248548,
+      "longitude": -121.03351
+    }
+  },
+  "95323": {
+    "coordinates": {
+      "latitude": 37.6209117,
+      "longitude": -120.7005044
+    }
+  },
+  "95324": {
+    "coordinates": {
+      "latitude": 37.4069089,
+      "longitude": -120.8728615
+    }
+  },
+  "95325": {
+    "coordinates": {
+      "latitude": 37.4741999,
+      "longitude": -120.2628111
+    }
+  },
+  "95326": {
+    "coordinates": {
+      "latitude": 37.5939016,
+      "longitude": -120.8613785
+    }
+  },
+  "95327": {
+    "coordinates": {
+      "latitude": 37.8475928,
+      "longitude": -120.4818446
+    }
+  },
+  "95328": {
+    "coordinates": {
+      "latitude": 37.5580692,
+      "longitude": -120.9101738
+    }
+  },
+  "95329": {
+    "coordinates": {
+      "latitude": 37.6547297,
+      "longitude": -120.4127161
+    }
+  },
+  "95330": {
+    "coordinates": {
+      "latitude": 37.8134216,
+      "longitude": -121.2969674
+    }
+  },
+  "95333": {
+    "coordinates": {
+      "latitude": 37.2407962,
+      "longitude": -120.2281933
+    }
+  },
+  "95334": {
+    "coordinates": {
+      "latitude": 37.2914925,
+      "longitude": -120.734995
+    }
+  },
+  "95335": {
+    "coordinates": {
+      "latitude": 38.093014,
+      "longitude": -120.134325
+    }
+  },
+  "95336": {
+    "coordinates": {
+      "latitude": 37.8403398,
+      "longitude": -121.2053963
+    }
+  },
+  "95337": {
+    "coordinates": {
+      "latitude": 37.7630254,
+      "longitude": -121.2397438
+    }
+  },
+  "95338": {
+    "coordinates": {
+      "latitude": 37.4610214,
+      "longitude": -119.9277947
+    }
+  },
+  "95340": {
+    "coordinates": {
+      "latitude": 37.3444493,
+      "longitude": -120.4127161
+    }
+  },
+  "95341": {
+    "coordinates": {
+      "latitude": 37.2276426,
+      "longitude": -120.4818446
+    }
+  },
+  "95342": {
+    "coordinates": {
+      "latitude": 37.367315,
+      "longitude": -120.570634
+    }
+  },
+  "95343": {
+    "coordinates": {
+      "latitude": 37.3670436,
+      "longitude": -120.4444046
+    }
+  },
+  "95344": {
+    "coordinates": {
+      "latitude": 37.31,
+      "longitude": -120.48
+    }
+  },
+  "95345": {
+    "coordinates": {
+      "latitude": 37.5907442,
+      "longitude": -119.9856157
+    }
+  },
+  "95346": {
+    "coordinates": {
+      "latitude": 38.0613194,
+      "longitude": -120.1531568
+    }
+  },
+  "95347": {
+    "coordinates": {
+      "latitude": 37.8119589,
+      "longitude": -120.3011213
+    }
+  },
+  "95348": {
+    "coordinates": {
+      "latitude": 37.4283693,
+      "longitude": -120.4933624
+    }
+  },
+  "95350": {
+    "coordinates": {
+      "latitude": 37.6697463,
+      "longitude": -120.9991032
+    }
+  },
+  "95351": {
+    "coordinates": {
+      "latitude": 37.6183927,
+      "longitude": -120.9933678
+    }
+  },
+  "95352": {
+    "coordinates": {
+      "latitude": 37.6599999,
+      "longitude": -121.02
+    }
+  },
+  "95353": {
+    "coordinates": {
+      "latitude": 37.64,
+      "longitude": -121
+    }
+  },
+  "95354": {
+    "coordinates": {
+      "latitude": 37.6346973,
+      "longitude": -120.9704234
+    }
+  },
+  "95355": {
+    "coordinates": {
+      "latitude": 37.6704504,
+      "longitude": -120.9302603
+    }
+  },
+  "95356": {
+    "coordinates": {
+      "latitude": 37.7208684,
+      "longitude": -121.0220422
+    }
+  },
+  "95357": {
+    "coordinates": {
+      "latitude": 37.6644618,
+      "longitude": -120.8843434
+    }
+  },
+  "95358": {
+    "coordinates": {
+      "latitude": 37.6107909,
+      "longitude": -121.1022942
+    }
+  },
+  "95360": {
+    "coordinates": {
+      "latitude": 37.2490019,
+      "longitude": -121.2168466
+    }
+  },
+  "95361": {
+    "coordinates": {
+      "latitude": 37.8189573,
+      "longitude": -120.8498944
+    }
+  },
+  "95363": {
+    "coordinates": {
+      "latitude": 37.481683,
+      "longitude": -121.1481284
+    }
+  },
+  "95364": {
+    "coordinates": {
+      "latitude": 38.2099465,
+      "longitude": -119.742604
+    }
+  },
+  "95365": {
+    "coordinates": {
+      "latitude": 37.3056776,
+      "longitude": -120.3349024
+    }
+  },
+  "95366": {
+    "coordinates": {
+      "latitude": 37.7514303,
+      "longitude": -121.1481284
+    }
+  },
+  "95367": {
+    "coordinates": {
+      "latitude": 37.7280941,
+      "longitude": -120.9474747
+    }
+  },
+  "95368": {
+    "coordinates": {
+      "latitude": 37.71693270000001,
+      "longitude": -121.0851019
+    }
+  },
+  "95369": {
+    "coordinates": {
+      "latitude": 37.5385285,
+      "longitude": -120.4127161
+    }
+  },
+  "95370": {
+    "coordinates": {
+      "latitude": 37.9768028,
+      "longitude": -120.3666099
+    }
+  },
+  "95372": {
+    "coordinates": {
+      "latitude": 37.9901931,
+      "longitude": -120.2599266
+    }
+  },
+  "95373": {
+    "coordinates": {
+      "latitude": 37.9775402,
+      "longitude": -120.3249959
+    }
+  },
+  "95374": {
+    "coordinates": {
+      "latitude": 37.30389419999999,
+      "longitude": -120.8269231
+    }
+  },
+  "95375": {
+    "coordinates": {
+      "latitude": 38.2223331,
+      "longitude": -120.0087372
+    }
+  },
+  "95376": {
+    "coordinates": {
+      "latitude": 37.7345254,
+      "longitude": -121.43419
+    }
+  },
+  "95377": {
+    "coordinates": {
+      "latitude": 37.6571548,
+      "longitude": -121.4684703
+    }
+  },
+  "95378": {
+    "coordinates": {
+      "latitude": 37.6796674,
+      "longitude": -121.4299221
+    }
+  },
+  "95379": {
+    "coordinates": {
+      "latitude": 37.93901450000001,
+      "longitude": -120.1935663
+    }
+  },
+  "95380": {
+    "coordinates": {
+      "latitude": 37.47103329999999,
+      "longitude": -120.9187827
+    }
+  },
+  "95381": {
+    "coordinates": {
+      "latitude": 37.5323606,
+      "longitude": -120.8811142
+    }
+  },
+  "95382": {
+    "coordinates": {
+      "latitude": 37.5359468,
+      "longitude": -120.8613785
+    }
+  },
+  "95383": {
+    "coordinates": {
+      "latitude": 38.0380251,
+      "longitude": -120.2304955
+    }
+  },
+  "95385": {
+    "coordinates": {
+      "latitude": 37.596139,
+      "longitude": -121.2511908
+    }
+  },
+  "95386": {
+    "coordinates": {
+      "latitude": 37.7050159,
+      "longitude": -120.6429991
+    }
+  },
+  "95387": {
+    "coordinates": {
+      "latitude": 37.5051827,
+      "longitude": -121.3312882
+    }
+  },
+  "95388": {
+    "coordinates": {
+      "latitude": 37.4216867,
+      "longitude": -120.5509358
+    }
+  },
+  "95389": {
+    "coordinates": {
+      "latitude": 37.6415479,
+      "longitude": -119.6267347
+    }
+  },
+  "95390": {
+    "coordinates": {
+      "latitude": 37.60396,
+      "longitude": -120.937052
+    }
+  },
+  "95397": {
+    "coordinates": {
+      "latitude": 37.6599999,
+      "longitude": -121.02
+    }
+  },
+  "95401": {
+    "coordinates": {
+      "latitude": 38.4409697,
+      "longitude": -122.7971649
+    }
+  },
+  "95402": {
+    "coordinates": {
+      "latitude": 38.4399754,
+      "longitude": -122.710764
+    }
+  },
+  "95403": {
+    "coordinates": {
+      "latitude": 38.4739555,
+      "longitude": -122.7520139
+    }
+  },
+  "95404": {
+    "coordinates": {
+      "latitude": 38.5386881,
+      "longitude": -122.695547
+    }
+  },
+  "95405": {
+    "coordinates": {
+      "latitude": 38.43922999999999,
+      "longitude": -122.6673018
+    }
+  },
+  "95406": {
+    "coordinates": {
+      "latitude": 38.44,
+      "longitude": -122.71
+    }
+  },
+  "95407": {
+    "coordinates": {
+      "latitude": 38.3986068,
+      "longitude": -122.7520139
+    }
+  },
+  "95408": {
+    "coordinates": {
+      "latitude": 38.463088,
+      "longitude": -122.989975
+    }
+  },
+  "95409": {
+    "coordinates": {
+      "latitude": 38.4668525,
+      "longitude": -122.593828
+    }
+  },
+  "95410": {
+    "coordinates": {
+      "latitude": 39.2134955,
+      "longitude": -123.7629465
+    }
+  },
+  "95412": {
+    "coordinates": {
+      "latitude": 38.7138916,
+      "longitude": -123.3261671
+    }
+  },
+  "95415": {
+    "coordinates": {
+      "latitude": 39.022009,
+      "longitude": -123.3822764
+    }
+  },
+  "95416": {
+    "coordinates": {
+      "latitude": 38.3137649,
+      "longitude": -122.4812958
+    }
+  },
+  "95417": {
+    "coordinates": {
+      "latitude": 39.6867934,
+      "longitude": -123.6399562
+    }
+  },
+  "95418": {
+    "coordinates": {
+      "latitude": 39.2346429,
+      "longitude": -123.2023912
+    }
+  },
+  "95419": {
+    "coordinates": {
+      "latitude": 38.4248846,
+      "longitude": -122.9582487
+    }
+  },
+  "95420": {
+    "coordinates": {
+      "latitude": 39.338086,
+      "longitude": -123.7350084
+    }
+  },
+  "95421": {
+    "coordinates": {
+      "latitude": 38.6073529,
+      "longitude": -123.1913722
+    }
+  },
+  "95422": {
+    "coordinates": {
+      "latitude": 38.9713832,
+      "longitude": -122.6616518
+    }
+  },
+  "95423": {
+    "coordinates": {
+      "latitude": 39.0453964,
+      "longitude": -122.5146439
+    }
+  },
+  "95424": {
+    "coordinates": {
+      "latitude": 38.96787630000001,
+      "longitude": -122.6612483
+    }
+  },
+  "95425": {
+    "coordinates": {
+      "latitude": 38.8143447,
+      "longitude": -123.0113568
+    }
+  },
+  "95426": {
+    "coordinates": {
+      "latitude": 38.82142959999999,
+      "longitude": -122.7191963
+    }
+  },
+  "95427": {
+    "coordinates": {
+      "latitude": 39.2365758,
+      "longitude": -123.5504076
+    }
+  },
+  "95428": {
+    "coordinates": {
+      "latitude": 39.8066831,
+      "longitude": -123.213851
+    }
+  },
+  "95429": {
+    "coordinates": {
+      "latitude": 39.6850497,
+      "longitude": -123.1913722
+    }
+  },
+  "95430": {
+    "coordinates": {
+      "latitude": 38.4373944,
+      "longitude": -123.0620193
+    }
+  },
+  "95431": {
+    "coordinates": {
+      "latitude": 38.3634225,
+      "longitude": -122.5279928
+    }
+  },
+  "95432": {
+    "coordinates": {
+      "latitude": 39.0963141,
+      "longitude": -123.6399562
+    }
+  },
+  "95433": {
+    "coordinates": {
+      "latitude": 38.3004099,
+      "longitude": -122.486703
+    }
+  },
+  "95435": {
+    "coordinates": {
+      "latitude": 39.0037467,
+      "longitude": -122.8750737
+    }
+  },
+  "95436": {
+    "coordinates": {
+      "latitude": 38.4924543,
+      "longitude": -122.9324972
+    }
+  },
+  "95437": {
+    "coordinates": {
+      "latitude": 39.4513714,
+      "longitude": -123.6846987
+    }
+  },
+  "95439": {
+    "coordinates": {
+      "latitude": 38.4886363,
+      "longitude": -122.7802357
+    }
+  },
+  "95441": {
+    "coordinates": {
+      "latitude": 38.7109062,
+      "longitude": -123.1014056
+    }
+  },
+  "95442": {
+    "coordinates": {
+      "latitude": 38.3747503,
+      "longitude": -122.5259596
+    }
+  },
+  "95443": {
+    "coordinates": {
+      "latitude": 39.0322199,
+      "longitude": -122.7403702
+    }
+  },
+  "95444": {
+    "coordinates": {
+      "latitude": 38.4336687,
+      "longitude": -122.8690828
+    }
+  },
+  "95445": {
+    "coordinates": {
+      "latitude": 38.8053731,
+      "longitude": -123.5056016
+    }
+  },
+  "95446": {
+    "coordinates": {
+      "latitude": 38.5274588,
+      "longitude": -123.000095
+    }
+  },
+  "95448": {
+    "coordinates": {
+      "latitude": 38.6323169,
+      "longitude": -122.8761309
+    }
+  },
+  "95449": {
+    "coordinates": {
+      "latitude": 38.9351173,
+      "longitude": -123.1014056
+    }
+  },
+  "95450": {
+    "coordinates": {
+      "latitude": 38.4542093,
+      "longitude": -123.1126559
+    }
+  },
+  "95451": {
+    "coordinates": {
+      "latitude": 38.9230082,
+      "longitude": -122.7858791
+    }
+  },
+  "95452": {
+    "coordinates": {
+      "latitude": 38.4213907,
+      "longitude": -122.5429309
+    }
+  },
+  "95453": {
+    "coordinates": {
+      "latitude": 39.0784484,
+      "longitude": -122.9437667
+    }
+  },
+  "95454": {
+    "coordinates": {
+      "latitude": 39.855248,
+      "longitude": -123.5175413
+    }
+  },
+  "95456": {
+    "coordinates": {
+      "latitude": 39.2717672,
+      "longitude": -123.7898088
+    }
+  },
+  "95457": {
+    "coordinates": {
+      "latitude": 38.858136,
+      "longitude": -122.5146439
+    }
+  },
+  "95458": {
+    "coordinates": {
+      "latitude": 39.1039647,
+      "longitude": -122.7745919
+    }
+  },
+  "95459": {
+    "coordinates": {
+      "latitude": 38.9624117,
+      "longitude": -123.5951925
+    }
+  },
+  "95460": {
+    "coordinates": {
+      "latitude": 39.2908752,
+      "longitude": -123.6958809
+    }
+  },
+  "95461": {
+    "coordinates": {
+      "latitude": 38.7548746,
+      "longitude": -122.6051351
+    }
+  },
+  "95462": {
+    "coordinates": {
+      "latitude": 38.4672117,
+      "longitude": -123.0198024
+    }
+  },
+  "95463": {
+    "coordinates": {
+      "latitude": 39.1268389,
+      "longitude": -123.5532073
+    }
+  },
+  "95464": {
+    "coordinates": {
+      "latitude": 39.1112521,
+      "longitude": -122.8253741
+    }
+  },
+  "95465": {
+    "coordinates": {
+      "latitude": 38.3958794,
+      "longitude": -123.000095
+    }
+  },
+  "95466": {
+    "coordinates": {
+      "latitude": 39.1028702,
+      "longitude": -123.5056016
+    }
+  },
+  "95468": {
+    "coordinates": {
+      "latitude": 38.9025795,
+      "longitude": -123.5504076
+    }
+  },
+  "95469": {
+    "coordinates": {
+      "latitude": 39.4213799,
+      "longitude": -123.0338767
+    }
+  },
+  "95470": {
+    "coordinates": {
+      "latitude": 39.28811839999999,
+      "longitude": -123.2475594
+    }
+  },
+  "95471": {
+    "coordinates": {
+      "latitude": 38.5212786,
+      "longitude": -122.9816867
+    }
+  },
+  "95472": {
+    "coordinates": {
+      "latitude": 38.4067427,
+      "longitude": -122.8761309
+    }
+  },
+  "95473": {
+    "coordinates": {
+      "latitude": 38.4,
+      "longitude": -122.82
+    }
+  },
+  "95476": {
+    "coordinates": {
+      "latitude": 38.2315738,
+      "longitude": -122.4693688
+    }
+  },
+  "95480": {
+    "coordinates": {
+      "latitude": 38.7445043,
+      "longitude": -123.4775871
+    }
+  },
+  "95481": {
+    "coordinates": {
+      "latitude": 39.1331805,
+      "longitude": -123.1663077
+    }
+  },
+  "95482": {
+    "coordinates": {
+      "latitude": 39.14119700000001,
+      "longitude": -123.213851
+    }
+  },
+  "95485": {
+    "coordinates": {
+      "latitude": 39.2159095,
+      "longitude": -122.9212265
+    }
+  },
+  "95486": {
+    "coordinates": {
+      "latitude": 38.4733269,
+      "longitude": -123.023673
+    }
+  },
+  "95487": {
+    "coordinates": {
+      "latitude": 38.2713236,
+      "longitude": -122.4390895
+    }
+  },
+  "95488": {
+    "coordinates": {
+      "latitude": 39.716228,
+      "longitude": -123.7741195
+    }
+  },
+  "95490": {
+    "coordinates": {
+      "latitude": 39.505272,
+      "longitude": -123.3486147
+    }
+  },
+  "95492": {
+    "coordinates": {
+      "latitude": 38.54676570000001,
+      "longitude": -122.8197329
+    }
+  },
+  "95493": {
+    "coordinates": {
+      "latitude": 39.225185,
+      "longitude": -122.9944636
+    }
+  },
+  "95494": {
+    "coordinates": {
+      "latitude": 38.9004765,
+      "longitude": -123.3261671
+    }
+  },
+  "95497": {
+    "coordinates": {
+      "latitude": 38.68053,
+      "longitude": -123.42889
+    }
+  },
+  "95501": {
+    "coordinates": {
+      "latitude": 40.8134774,
+      "longitude": -124.1460963
+    }
+  },
+  "95502": {
+    "coordinates": {
+      "latitude": 40.8,
+      "longitude": -124.17
+    }
+  },
+  "95503": {
+    "coordinates": {
+      "latitude": 40.7306343,
+      "longitude": -124.082682
+    }
+  },
+  "95511": {
+    "coordinates": {
+      "latitude": 40.1695107,
+      "longitude": -123.600585
+    }
+  },
+  "95514": {
+    "coordinates": {
+      "latitude": 40.3124098,
+      "longitude": -123.6464633
+    }
+  },
+  "95517": {
+    "coordinates": {
+      "latitude": 38.692808,
+      "longitude": -120.818771
+    }
+  },
+  "95518": {
+    "coordinates": {
+      "latitude": 40.87,
+      "longitude": -124.08
+    }
+  },
+  "95519": {
+    "coordinates": {
+      "latitude": 40.9373196,
+      "longitude": -124.0312661
+    }
+  },
+  "95521": {
+    "coordinates": {
+      "latitude": 40.8805372,
+      "longitude": -124.0874754
+    }
+  },
+  "95522": {
+    "coordinates": {
+      "latitude": 40.878317,
+      "longitude": -124.075673
+    }
+  },
+  "95524": {
+    "coordinates": {
+      "latitude": 40.8221629,
+      "longitude": -124.0494434
+    }
+  },
+  "95525": {
+    "coordinates": {
+      "latitude": 40.9309419,
+      "longitude": -123.8223634
+    }
+  },
+  "95526": {
+    "coordinates": {
+      "latitude": 40.4606038,
+      "longitude": -123.6497843
+    }
+  },
+  "95527": {
+    "coordinates": {
+      "latitude": 40.7778073,
+      "longitude": -123.4838156
+    }
+  },
+  "95528": {
+    "coordinates": {
+      "latitude": 40.4931837,
+      "longitude": -123.8913602
+    }
+  },
+  "95531": {
+    "coordinates": {
+      "latitude": 41.7557501,
+      "longitude": -124.2025913
+    }
+  },
+  "95532": {
+    "coordinates": {
+      "latitude": 41.8536364,
+      "longitude": -124.1496841
+    }
+  },
+  "95534": {
+    "coordinates": {
+      "latitude": 40.77,
+      "longitude": -124.14
+    }
+  },
+  "95536": {
+    "coordinates": {
+      "latitude": 40.4998302,
+      "longitude": -124.2649051
+    }
+  },
+  "95537": {
+    "coordinates": {
+      "latitude": 40.7242937,
+      "longitude": -124.2178534
+    }
+  },
+  "95538": {
+    "coordinates": {
+      "latitude": 41.75062,
+      "longitude": -124.19856
+    }
+  },
+  "95540": {
+    "coordinates": {
+      "latitude": 40.60718050000001,
+      "longitude": -124.1132746
+    }
+  },
+  "95542": {
+    "coordinates": {
+      "latitude": 40.0893047,
+      "longitude": -123.7038831
+    }
+  },
+  "95543": {
+    "coordinates": {
+      "latitude": 41.8717464,
+      "longitude": -123.881651
+    }
+  },
+  "95545": {
+    "coordinates": {
+      "latitude": 40.2137974,
+      "longitude": -124.1687538
+    }
+  },
+  "95546": {
+    "coordinates": {
+      "latitude": 41.1122923,
+      "longitude": -123.7339176
+    }
+  },
+  "95547": {
+    "coordinates": {
+      "latitude": 40.5659648,
+      "longitude": -124.0817118
+    }
+  },
+  "95548": {
+    "coordinates": {
+      "latitude": 41.5863265,
+      "longitude": -124.0391342
+    }
+  },
+  "95549": {
+    "coordinates": {
+      "latitude": 40.6161714,
+      "longitude": -123.8602647
+    }
+  },
+  "95550": {
+    "coordinates": {
+      "latitude": 40.7395757,
+      "longitude": -123.8289747
+    }
+  },
+  "95551": {
+    "coordinates": {
+      "latitude": 40.6691318,
+      "longitude": -124.1816517
+    }
+  },
+  "95552": {
+    "coordinates": {
+      "latitude": 40.1847614,
+      "longitude": -123.1832226
+    }
+  },
+  "95553": {
+    "coordinates": {
+      "latitude": 40.2661253,
+      "longitude": -123.9278088
+    }
+  },
+  "95554": {
+    "coordinates": {
+      "latitude": 40.2676912,
+      "longitude": -123.7823278
+    }
+  },
+  "95555": {
+    "coordinates": {
+      "latitude": 41.2677058,
+      "longitude": -123.9273397
+    }
+  },
+  "95556": {
+    "coordinates": {
+      "latitude": 41.3097656,
+      "longitude": -123.5983136
+    }
+  },
+  "95558": {
+    "coordinates": {
+      "latitude": 40.2800107,
+      "longitude": -124.1939287
+    }
+  },
+  "95559": {
+    "coordinates": {
+      "latitude": 40.1966177,
+      "longitude": -123.8004324
+    }
+  },
+  "95560": {
+    "coordinates": {
+      "latitude": 40.13103479999999,
+      "longitude": -123.858434
+    }
+  },
+  "95562": {
+    "coordinates": {
+      "latitude": 40.4175329,
+      "longitude": -124.1184839
+    }
+  },
+  "95563": {
+    "coordinates": {
+      "latitude": 40.8706481,
+      "longitude": -123.4594869
+    }
+  },
+  "95564": {
+    "coordinates": {
+      "latitude": 40.7865168,
+      "longitude": -124.2052154
+    }
+  },
+  "95565": {
+    "coordinates": {
+      "latitude": 40.44518910000001,
+      "longitude": -124.0075476
+    }
+  },
+  "95567": {
+    "coordinates": {
+      "latitude": 41.9741584,
+      "longitude": -124.1576164
+    }
+  },
+  "95568": {
+    "coordinates": {
+      "latitude": 41.4660867,
+      "longitude": -123.4725126
+    }
+  },
+  "95569": {
+    "coordinates": {
+      "latitude": 40.3883348,
+      "longitude": -123.8970136
+    }
+  },
+  "95570": {
+    "coordinates": {
+      "latitude": 41.1509241,
+      "longitude": -124.1048271
+    }
+  },
+  "95571": {
+    "coordinates": {
+      "latitude": 40.3322706,
+      "longitude": -123.9111517
+    }
+  },
+  "95573": {
+    "coordinates": {
+      "latitude": 40.9089201,
+      "longitude": -123.6596995
+    }
+  },
+  "95585": {
+    "coordinates": {
+      "latitude": 39.8167143,
+      "longitude": -123.6916184
+    }
+  },
+  "95587": {
+    "coordinates": {
+      "latitude": 39.9507351,
+      "longitude": -123.7599728
+    }
+  },
+  "95589": {
+    "coordinates": {
+      "latitude": 40.0203165,
+      "longitude": -123.9688785
+    }
+  },
+  "95592": {
+    "coordinates": {
+      "latitude": 38.098737,
+      "longitude": -122.271251
+    }
+  },
+  "95595": {
+    "coordinates": {
+      "latitude": 40.1778769,
+      "longitude": -123.433043
+    }
+  },
+  "95601": {
+    "coordinates": {
+      "latitude": 38.4206939,
+      "longitude": -120.8305126
+    }
+  },
+  "95602": {
+    "coordinates": {
+      "latitude": 38.9851375,
+      "longitude": -121.1022942
+    }
+  },
+  "95603": {
+    "coordinates": {
+      "latitude": 38.9101752,
+      "longitude": -121.067907
+    }
+  },
+  "95604": {
+    "coordinates": {
+      "latitude": 38.9111705,
+      "longitude": -121.0806932
+    }
+  },
+  "95605": {
+    "coordinates": {
+      "latitude": 38.5974642,
+      "longitude": -121.531291
+    }
+  },
+  "95606": {
+    "coordinates": {
+      "latitude": 38.7684692,
+      "longitude": -122.1973081
+    }
+  },
+  "95607": {
+    "coordinates": {
+      "latitude": 38.7963491,
+      "longitude": -122.1064668
+    }
+  },
+  "95608": {
+    "coordinates": {
+      "latitude": 38.6272793,
+      "longitude": -121.3198491
+    }
+  },
+  "95609": {
+    "coordinates": {
+      "latitude": 38.62,
+      "longitude": -121.33
+    }
+  },
+  "95610": {
+    "coordinates": {
+      "latitude": 38.6977447,
+      "longitude": -121.2740813
+    }
+  },
+  "95611": {
+    "coordinates": {
+      "latitude": 38.71,
+      "longitude": -121.28
+    }
+  },
+  "95612": {
+    "coordinates": {
+      "latitude": 38.3807344,
+      "longitude": -121.6054893
+    }
+  },
+  "95613": {
+    "coordinates": {
+      "latitude": 38.7973333,
+      "longitude": -120.88829
+    }
+  },
+  "95614": {
+    "coordinates": {
+      "latitude": 38.8925457,
+      "longitude": -120.9991032
+    }
+  },
+  "95615": {
+    "coordinates": {
+      "latitude": 38.331258,
+      "longitude": -121.548418
+    }
+  },
+  "95616": {
+    "coordinates": {
+      "latitude": 38.5474428,
+      "longitude": -121.7765309
+    }
+  },
+  "95617": {
+    "coordinates": {
+      "latitude": 38.55,
+      "longitude": -121.74
+    }
+  },
+  "95618": {
+    "coordinates": {
+      "latitude": 38.518893,
+      "longitude": -121.6511258
+    }
+  },
+  "95619": {
+    "coordinates": {
+      "latitude": 38.6869632,
+      "longitude": -120.8096918
+    }
+  },
+  "95620": {
+    "coordinates": {
+      "latitude": 38.3897438,
+      "longitude": -121.7651362
+    }
+  },
+  "95621": {
+    "coordinates": {
+      "latitude": 38.6940006,
+      "longitude": -121.3026883
+    }
+  },
+  "95623": {
+    "coordinates": {
+      "latitude": 38.6100779,
+      "longitude": -120.8613785
+    }
+  },
+  "95624": {
+    "coordinates": {
+      "latitude": 38.4244019,
+      "longitude": -121.3312882
+    }
+  },
+  "95625": {
+    "coordinates": {
+      "latitude": 38.3455976,
+      "longitude": -121.905352
+    }
+  },
+  "95626": {
+    "coordinates": {
+      "latitude": 38.7190893,
+      "longitude": -121.4570447
+    }
+  },
+  "95627": {
+    "coordinates": {
+      "latitude": 38.6733773,
+      "longitude": -122.0155491
+    }
+  },
+  "95628": {
+    "coordinates": {
+      "latitude": 38.6506766,
+      "longitude": -121.2569138
+    }
+  },
+  "95629": {
+    "coordinates": {
+      "latitude": 38.5358153,
+      "longitude": -120.7234992
+    }
+  },
+  "95630": {
+    "coordinates": {
+      "latitude": 38.668585,
+      "longitude": -121.1481284
+    }
+  },
+  "95631": {
+    "coordinates": {
+      "latitude": 39.0793693,
+      "longitude": -120.7809676
+    }
+  },
+  "95632": {
+    "coordinates": {
+      "latitude": 38.2855625,
+      "longitude": -121.2855249
+    }
+  },
+  "95633": {
+    "coordinates": {
+      "latitude": 38.8520489,
+      "longitude": -120.7809676
+    }
+  },
+  "95634": {
+    "coordinates": {
+      "latitude": 38.9167124,
+      "longitude": -120.6890055
+    }
+  },
+  "95635": {
+    "coordinates": {
+      "latitude": 38.90051,
+      "longitude": -120.907304
+    }
+  },
+  "95636": {
+    "coordinates": {
+      "latitude": 38.6289451,
+      "longitude": -120.3666099
+    }
+  },
+  "95637": {
+    "coordinates": {
+      "latitude": 38.8297286,
+      "longitude": -122.2427
+    }
+  },
+  "95638": {
+    "coordinates": {
+      "latitude": 38.3395289,
+      "longitude": -121.1022942
+    }
+  },
+  "95639": {
+    "coordinates": {
+      "latitude": 38.3749489,
+      "longitude": -121.5055958
+    }
+  },
+  "95640": {
+    "coordinates": {
+      "latitude": 38.31682240000001,
+      "longitude": -120.9187827
+    }
+  },
+  "95641": {
+    "coordinates": {
+      "latitude": 38.1659627,
+      "longitude": -121.5598345
+    }
+  },
+  "95642": {
+    "coordinates": {
+      "latitude": 38.370187,
+      "longitude": -120.734995
+    }
+  },
+  "95644": {
+    "coordinates": {
+      "latitude": 38.43,
+      "longitude": -120.57
+    }
+  },
+  "95645": {
+    "coordinates": {
+      "latitude": 38.8933855,
+      "longitude": -121.7879244
+    }
+  },
+  "95646": {
+    "coordinates": {
+      "latitude": 38.6982463,
+      "longitude": -120.0723009
+    }
+  },
+  "95648": {
+    "coordinates": {
+      "latitude": 38.9052036,
+      "longitude": -121.3084088
+    }
+  },
+  "95650": {
+    "coordinates": {
+      "latitude": 38.8074133,
+      "longitude": -121.1595842
+    }
+  },
+  "95651": {
+    "coordinates": {
+      "latitude": 38.8210287,
+      "longitude": -120.9359987
+    }
+  },
+  "95652": {
+    "coordinates": {
+      "latitude": 38.6634039,
+      "longitude": -121.4056153
+    }
+  },
+  "95653": {
+    "coordinates": {
+      "latitude": 38.6780428,
+      "longitude": -121.9615308
+    }
+  },
+  "95654": {
+    "coordinates": {
+      "latitude": 38.36509,
+      "longitude": -120.79136
+    }
+  },
+  "95655": {
+    "coordinates": {
+      "latitude": 38.548973,
+      "longitude": -121.2798033
+    }
+  },
+  "95656": {
+    "coordinates": {
+      "latitude": 38.5516113,
+      "longitude": -120.7306842
+    }
+  },
+  "95658": {
+    "coordinates": {
+      "latitude": 38.8831341,
+      "longitude": -121.1595842
+    }
+  },
+  "95659": {
+    "coordinates": {
+      "latitude": 38.83528889999999,
+      "longitude": -121.6054893
+    }
+  },
+  "95660": {
+    "coordinates": {
+      "latitude": 38.6830879,
+      "longitude": -121.3713164
+    }
+  },
+  "95661": {
+    "coordinates": {
+      "latitude": 38.7424319,
+      "longitude": -121.2511908
+    }
+  },
+  "95662": {
+    "coordinates": {
+      "latitude": 38.692341,
+      "longitude": -121.2282958
+    }
+  },
+  "95663": {
+    "coordinates": {
+      "latitude": 38.8544033,
+      "longitude": -121.1767658
+    }
+  },
+  "95664": {
+    "coordinates": {
+      "latitude": 38.809388,
+      "longitude": -121.0564425
+    }
+  },
+  "95665": {
+    "coordinates": {
+      "latitude": 38.4096384,
+      "longitude": -120.6314948
+    }
+  },
+  "95666": {
+    "coordinates": {
+      "latitude": 38.4615033,
+      "longitude": -120.5509358
+    }
+  },
+  "95667": {
+    "coordinates": {
+      "latitude": 38.7370339,
+      "longitude": -120.8498944
+    }
+  },
+  "95668": {
+    "coordinates": {
+      "latitude": 38.824922,
+      "longitude": -121.5141615
+    }
+  },
+  "95669": {
+    "coordinates": {
+      "latitude": 38.4829024,
+      "longitude": -120.8728615
+    }
+  },
+  "95670": {
+    "coordinates": {
+      "latitude": 38.5961116,
+      "longitude": -121.2969674
+    }
+  },
+  "95671": {
+    "coordinates": {
+      "latitude": 38.6895773,
+      "longitude": -121.162469
+    }
+  },
+  "95672": {
+    "coordinates": {
+      "latitude": 38.7218957,
+      "longitude": -120.9991032
+    }
+  },
+  "95673": {
+    "coordinates": {
+      "latitude": 38.6880414,
+      "longitude": -121.43419
+    }
+  },
+  "95674": {
+    "coordinates": {
+      "latitude": 38.9578663,
+      "longitude": -121.4798948
+    }
+  },
+  "95675": {
+    "coordinates": {
+      "latitude": 38.54747589999999,
+      "longitude": -120.7428977
+    }
+  },
+  "95676": {
+    "coordinates": {
+      "latitude": 38.87727539999999,
+      "longitude": -121.685341
+    }
+  },
+  "95677": {
+    "coordinates": {
+      "latitude": 38.7870973,
+      "longitude": -121.2282958
+    }
+  },
+  "95678": {
+    "coordinates": {
+      "latitude": 38.7637052,
+      "longitude": -121.2912463
+    }
+  },
+  "95679": {
+    "coordinates": {
+      "latitude": 38.9160566,
+      "longitude": -122.3185465
+    }
+  },
+  "95680": {
+    "coordinates": {
+      "latitude": 38.2455111,
+      "longitude": -121.5526993
+    }
+  },
+  "95681": {
+    "coordinates": {
+      "latitude": 38.9988271,
+      "longitude": -121.3427262
+    }
+  },
+  "95682": {
+    "coordinates": {
+      "latitude": 38.6084554,
+      "longitude": -120.9646866
+    }
+  },
+  "95683": {
+    "coordinates": {
+      "latitude": 38.4919885,
+      "longitude": -121.1022942
+    }
+  },
+  "95684": {
+    "coordinates": {
+      "latitude": 38.576092,
+      "longitude": -120.5509358
+    }
+  },
+  "95685": {
+    "coordinates": {
+      "latitude": 38.4332877,
+      "longitude": -120.7809676
+    }
+  },
+  "95686": {
+    "coordinates": {
+      "latitude": 38.231148,
+      "longitude": -121.4770388
+    }
+  },
+  "95687": {
+    "coordinates": {
+      "latitude": 38.3286205,
+      "longitude": -121.9359339
+    }
+  },
+  "95688": {
+    "coordinates": {
+      "latitude": 38.4087013,
+      "longitude": -122.0155491
+    }
+  },
+  "95689": {
+    "coordinates": {
+      "latitude": 38.498524,
+      "longitude": -120.6545022
+    }
+  },
+  "95690": {
+    "coordinates": {
+      "latitude": 38.2285458,
+      "longitude": -121.6054893
+    }
+  },
+  "95691": {
+    "coordinates": {
+      "latitude": 38.5815697,
+      "longitude": -121.5312934
+    }
+  },
+  "95692": {
+    "coordinates": {
+      "latitude": 39.0409308,
+      "longitude": -121.422761
+    }
+  },
+  "95693": {
+    "coordinates": {
+      "latitude": 38.3888359,
+      "longitude": -121.193945
+    }
+  },
+  "95694": {
+    "coordinates": {
+      "latitude": 38.5600699,
+      "longitude": -122.0155491
+    }
+  },
+  "95695": {
+    "coordinates": {
+      "latitude": 38.6651725,
+      "longitude": -121.856261
+    }
+  },
+  "95696": {
+    "coordinates": {
+      "latitude": 38.43,
+      "longitude": -122.02
+    }
+  },
+  "95697": {
+    "coordinates": {
+      "latitude": 38.7330062,
+      "longitude": -121.8057244
+    }
+  },
+  "95698": {
+    "coordinates": {
+      "latitude": 38.8018286,
+      "longitude": -121.918866
+    }
+  },
+  "95699": {
+    "coordinates": {
+      "latitude": 38.4414366,
+      "longitude": -120.8545599
+    }
+  },
+  "95701": {
+    "coordinates": {
+      "latitude": 39.2176947,
+      "longitude": -120.792458
+    }
+  },
+  "95703": {
+    "coordinates": {
+      "latitude": 38.993576,
+      "longitude": -120.9933678
+    }
+  },
+  "95709": {
+    "coordinates": {
+      "latitude": 38.7586142,
+      "longitude": -120.6775054
+    }
+  },
+  "95712": {
+    "coordinates": {
+      "latitude": 39.1458527,
+      "longitude": -120.9671958
+    }
+  },
+  "95713": {
+    "coordinates": {
+      "latitude": 39.1007512,
+      "longitude": -120.9532041
+    }
+  },
+  "95714": {
+    "coordinates": {
+      "latitude": 39.2105043,
+      "longitude": -120.8412807
+    }
+  },
+  "95715": {
+    "coordinates": {
+      "latitude": 39.2444916,
+      "longitude": -120.7005044
+    }
+  },
+  "95717": {
+    "coordinates": {
+      "latitude": 39.1884372,
+      "longitude": -120.844152
+    }
+  },
+  "95720": {
+    "coordinates": {
+      "latitude": 38.7828723,
+      "longitude": -120.2281933
+    }
+  },
+  "95721": {
+    "coordinates": {
+      "latitude": 38.8349932,
+      "longitude": -120.078078
+    }
+  },
+  "95722": {
+    "coordinates": {
+      "latitude": 38.9993271,
+      "longitude": -121.0220422
+    }
+  },
+  "95724": {
+    "coordinates": {
+      "latitude": 39.3138084,
+      "longitude": -120.3421093
+    }
+  },
+  "95726": {
+    "coordinates": {
+      "latitude": 38.7931476,
+      "longitude": -120.4588059
+    }
+  },
+  "95728": {
+    "coordinates": {
+      "latitude": 39.309122,
+      "longitude": -120.3954282
+    }
+  },
+  "95735": {
+    "coordinates": {
+      "latitude": 38.8153606,
+      "longitude": -120.147383
+    }
+  },
+  "95736": {
+    "coordinates": {
+      "latitude": 39.0437404,
+      "longitude": -120.971874
+    }
+  },
+  "95741": {
+    "coordinates": {
+      "latitude": 38.59,
+      "longitude": -121.3
+    }
+  },
+  "95742": {
+    "coordinates": {
+      "latitude": 38.5791051,
+      "longitude": -121.193945
+    }
+  },
+  "95743": {
+    "coordinates": {
+      "latitude": 38.377411,
+      "longitude": -121.444429
+    }
+  },
+  "95746": {
+    "coordinates": {
+      "latitude": 38.743802,
+      "longitude": -121.1824925
+    }
+  },
+  "95747": {
+    "coordinates": {
+      "latitude": 38.7902545,
+      "longitude": -121.3770336
+    }
+  },
+  "95749": {
+    "coordinates": {
+      "latitude": 38.195804,
+      "longitude": -120.679713
+    }
+  },
+  "95758": {
+    "coordinates": {
+      "latitude": 38.4223702,
+      "longitude": -121.43419
+    }
+  },
+  "95759": {
+    "coordinates": {
+      "latitude": 38.4099999,
+      "longitude": -121.38
+    }
+  },
+  "95762": {
+    "coordinates": {
+      "latitude": 38.6575905,
+      "longitude": -121.0564425
+    }
+  },
+  "95763": {
+    "coordinates": {
+      "latitude": 38.68,
+      "longitude": -121.18
+    }
+  },
+  "95765": {
+    "coordinates": {
+      "latitude": 38.8113924,
+      "longitude": -121.2740813
+    }
+  },
+  "95771": {
+    "coordinates": {
+      "latitude": 40.036998,
+      "longitude": -121.831299
+    }
+  },
+  "95776": {
+    "coordinates": {
+      "latitude": 38.6944843,
+      "longitude": -121.6967438
+    }
+  },
+  "95798": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.53
+    }
+  },
+  "95799": {
+    "coordinates": {
+      "latitude": 38.5731375,
+      "longitude": -121.5680395
+    }
+  },
+  "95812": {
+    "coordinates": {
+      "latitude": 38.58,
+      "longitude": -121.49
+    }
+  },
+  "95813": {
+    "coordinates": {
+      "latitude": 38.6024828,
+      "longitude": -121.4470463
+    }
+  },
+  "95814": {
+    "coordinates": {
+      "latitude": 38.5824933,
+      "longitude": -121.4941738
+    }
+  },
+  "95815": {
+    "coordinates": {
+      "latitude": 38.5963157,
+      "longitude": -121.4399041
+    }
+  },
+  "95816": {
+    "coordinates": {
+      "latitude": 38.58001840000001,
+      "longitude": -121.4627576
+    }
+  },
+  "95817": {
+    "coordinates": {
+      "latitude": 38.5500434,
+      "longitude": -121.4599012
+    }
+  },
+  "95818": {
+    "coordinates": {
+      "latitude": 38.56030560000001,
+      "longitude": -121.4970294
+    }
+  },
+  "95819": {
+    "coordinates": {
+      "latitude": 38.5678631,
+      "longitude": -121.4399041
+    }
+  },
+  "95820": {
+    "coordinates": {
+      "latitude": 38.5359933,
+      "longitude": -121.4513314
+    }
+  },
+  "95821": {
+    "coordinates": {
+      "latitude": 38.6258567,
+      "longitude": -121.3884671
+    }
+  },
+  "95822": {
+    "coordinates": {
+      "latitude": 38.5128714,
+      "longitude": -121.4970294
+    }
+  },
+  "95823": {
+    "coordinates": {
+      "latitude": 38.4603864,
+      "longitude": -121.43419
+    }
+  },
+  "95824": {
+    "coordinates": {
+      "latitude": 38.517011,
+      "longitude": -121.4513314
+    }
+  },
+  "95825": {
+    "coordinates": {
+      "latitude": 38.5890819,
+      "longitude": -121.4084731
+    }
+  },
+  "95826": {
+    "coordinates": {
+      "latitude": 38.5499634,
+      "longitude": -121.3884671
+    }
+  },
+  "95827": {
+    "coordinates": {
+      "latitude": 38.5544039,
+      "longitude": -121.3255688
+    }
+  },
+  "95828": {
+    "coordinates": {
+      "latitude": 38.4929881,
+      "longitude": -121.3884671
+    }
+  },
+  "95829": {
+    "coordinates": {
+      "latitude": 38.4943521,
+      "longitude": -121.3198491
+    }
+  },
+  "95830": {
+    "coordinates": {
+      "latitude": 38.4858337,
+      "longitude": -121.2683591
+    }
+  },
+  "95831": {
+    "coordinates": {
+      "latitude": 38.4901072,
+      "longitude": -121.5255815
+    }
+  },
+  "95832": {
+    "coordinates": {
+      "latitude": 38.4369084,
+      "longitude": -121.4970294
+    }
+  },
+  "95833": {
+    "coordinates": {
+      "latitude": 38.6198298,
+      "longitude": -121.5198716
+    }
+  },
+  "95834": {
+    "coordinates": {
+      "latitude": 38.6418022,
+      "longitude": -121.5255815
+    }
+  },
+  "95835": {
+    "coordinates": {
+      "latitude": 38.6853213,
+      "longitude": -121.5541264
+    }
+  },
+  "95836": {
+    "coordinates": {
+      "latitude": 38.7143133,
+      "longitude": -121.5405072
+    }
+  },
+  "95837": {
+    "coordinates": {
+      "latitude": 38.6969922,
+      "longitude": -121.5940773
+    }
+  },
+  "95838": {
+    "coordinates": {
+      "latitude": 38.643335,
+      "longitude": -121.4570447
+    }
+  },
+  "95840": {
+    "coordinates": {
+      "latitude": 38.5780265,
+      "longitude": -121.4805663
+    }
+  },
+  "95841": {
+    "coordinates": {
+      "latitude": 38.6614578,
+      "longitude": -121.3484448
+    }
+  },
+  "95842": {
+    "coordinates": {
+      "latitude": 38.6804131,
+      "longitude": -121.3484448
+    }
+  },
+  "95843": {
+    "coordinates": {
+      "latitude": 38.7149071,
+      "longitude": -121.3598812
+    }
+  },
+  "95851": {
+    "coordinates": {
+      "latitude": 38.6,
+      "longitude": -121.45
+    }
+  },
+  "95852": {
+    "coordinates": {
+      "latitude": 38.6,
+      "longitude": -121.45
+    }
+  },
+  "95853": {
+    "coordinates": {
+      "latitude": 38.6,
+      "longitude": -121.45
+    }
+  },
+  "95857": {
+    "coordinates": {
+      "latitude": 38.377411,
+      "longitude": -121.444429
+    }
+  },
+  "95860": {
+    "coordinates": {
+      "latitude": 38.61,
+      "longitude": -121.38
+    }
+  },
+  "95864": {
+    "coordinates": {
+      "latitude": 38.5848773,
+      "longitude": -121.3827505
+    }
+  },
+  "95865": {
+    "coordinates": {
+      "latitude": 38.6,
+      "longitude": -121.4
+    }
+  },
+  "95866": {
+    "coordinates": {
+      "latitude": 38.6,
+      "longitude": -121.4
+    }
+  },
+  "95867": {
+    "coordinates": {
+      "latitude": 38.5776665,
+      "longitude": -121.4800733
+    }
+  },
+  "95873": {
+    "coordinates": {
+      "latitude": 38.377411,
+      "longitude": -121.444429
+    }
+  },
+  "95887": {
+    "coordinates": {
+      "latitude": 38.377411,
+      "longitude": -121.444429
+    }
+  },
+  "95894": {
+    "coordinates": {
+      "latitude": 38.5574091,
+      "longitude": -121.4848927
+    }
+  },
+  "95899": {
+    "coordinates": {
+      "latitude": 38.54,
+      "longitude": -121.55
+    }
+  },
+  "95901": {
+    "coordinates": {
+      "latitude": 39.2392323,
+      "longitude": -121.5141615
+    }
+  },
+  "95903": {
+    "coordinates": {
+      "latitude": 39.1170917,
+      "longitude": -121.3884671
+    }
+  },
+  "95910": {
+    "coordinates": {
+      "latitude": 39.4678844,
+      "longitude": -120.8384093
+    }
+  },
+  "95912": {
+    "coordinates": {
+      "latitude": 39.0121645,
+      "longitude": -122.0155491
+    }
+  },
+  "95913": {
+    "coordinates": {
+      "latitude": 39.6299723,
+      "longitude": -122.2001457
+    }
+  },
+  "95914": {
+    "coordinates": {
+      "latitude": 39.417587,
+      "longitude": -121.3884671
+    }
+  },
+  "95915": {
+    "coordinates": {
+      "latitude": 39.9899476,
+      "longitude": -121.1595842
+    }
+  },
+  "95916": {
+    "coordinates": {
+      "latitude": 39.6685037,
+      "longitude": -121.3312882
+    }
+  },
+  "95917": {
+    "coordinates": {
+      "latitude": 39.4384517,
+      "longitude": -121.7537404
+    }
+  },
+  "95918": {
+    "coordinates": {
+      "latitude": 39.2939803,
+      "longitude": -121.3312882
+    }
+  },
+  "95919": {
+    "coordinates": {
+      "latitude": 39.4338542,
+      "longitude": -121.2397438
+    }
+  },
+  "95920": {
+    "coordinates": {
+      "latitude": 39.45176439999999,
+      "longitude": -121.9245556
+    }
+  },
+  "95922": {
+    "coordinates": {
+      "latitude": 39.4882143,
+      "longitude": -121.0564425
+    }
+  },
+  "95923": {
+    "coordinates": {
+      "latitude": 40.1854014,
+      "longitude": -121.1424001
+    }
+  },
+  "95924": {
+    "coordinates": {
+      "latitude": 39.1992233,
+      "longitude": -121.0227705
+    }
+  },
+  "95925": {
+    "coordinates": {
+      "latitude": 39.4828107,
+      "longitude": -121.1538564
+    }
+  },
+  "95926": {
+    "coordinates": {
+      "latitude": 39.7461315,
+      "longitude": -121.8448745
+    }
+  },
+  "95927": {
+    "coordinates": {
+      "latitude": 39.81,
+      "longitude": -121.94
+    }
+  },
+  "95928": {
+    "coordinates": {
+      "latitude": 39.703129,
+      "longitude": -121.8334868
+    }
+  },
+  "95929": {
+    "coordinates": {
+      "latitude": 39.735769,
+      "longitude": -121.8504463
+    }
+  },
+  "95930": {
+    "coordinates": {
+      "latitude": 39.5415926,
+      "longitude": -121.1767658
+    }
+  },
+  "95931": {
+    "coordinates": {
+      "latitude": 39.169245,
+      "longitude": -122.290204
+    }
+  },
+  "95932": {
+    "coordinates": {
+      "latitude": 39.2862047,
+      "longitude": -122.0382856
+    }
+  },
+  "95934": {
+    "coordinates": {
+      "latitude": 40.0579274,
+      "longitude": -120.9302603
+    }
+  },
+  "95935": {
+    "coordinates": {
+      "latitude": 39.3664259,
+      "longitude": -121.1824925
+    }
+  },
+  "95936": {
+    "coordinates": {
+      "latitude": 39.60673630000001,
+      "longitude": -120.7809676
+    }
+  },
+  "95937": {
+    "coordinates": {
+      "latitude": 38.8528976,
+      "longitude": -121.9984936
+    }
+  },
+  "95938": {
+    "coordinates": {
+      "latitude": 39.6053211,
+      "longitude": -121.7879244
+    }
+  },
+  "95939": {
+    "coordinates": {
+      "latitude": 39.535761,
+      "longitude": -122.6729515
+    }
+  },
+  "95940": {
+    "coordinates": {
+      "latitude": 39.51153000000001,
+      "longitude": -121.55755
+    }
+  },
+  "95941": {
+    "coordinates": {
+      "latitude": 39.5147718,
+      "longitude": -121.2511908
+    }
+  },
+  "95942": {
+    "coordinates": {
+      "latitude": 40.0694093,
+      "longitude": -121.6054893
+    }
+  },
+  "95943": {
+    "coordinates": {
+      "latitude": 39.597402,
+      "longitude": -122.026918
+    }
+  },
+  "95944": {
+    "coordinates": {
+      "latitude": 39.5265236,
+      "longitude": -120.8786026
+    }
+  },
+  "95945": {
+    "coordinates": {
+      "latitude": 39.1766853,
+      "longitude": -120.9646866
+    }
+  },
+  "95946": {
+    "coordinates": {
+      "latitude": 39.2836679,
+      "longitude": -121.2397438
+    }
+  },
+  "95947": {
+    "coordinates": {
+      "latitude": 40.1652914,
+      "longitude": -120.8498944
+    }
+  },
+  "95948": {
+    "coordinates": {
+      "latitude": 39.35777,
+      "longitude": -121.7423434
+    }
+  },
+  "95949": {
+    "coordinates": {
+      "latitude": 39.1105188,
+      "longitude": -121.1252135
+    }
+  },
+  "95950": {
+    "coordinates": {
+      "latitude": 39.0458649,
+      "longitude": -121.9359339
+    }
+  },
+  "95951": {
+    "coordinates": {
+      "latitude": 39.7388331,
+      "longitude": -122.0127067
+    }
+  },
+  "95953": {
+    "coordinates": {
+      "latitude": 39.269055,
+      "longitude": -121.7879244
+    }
+  },
+  "95954": {
+    "coordinates": {
+      "latitude": 39.8722768,
+      "longitude": -121.5826642
+    }
+  },
+  "95955": {
+    "coordinates": {
+      "latitude": 39.3364818,
+      "longitude": -122.2086579
+    }
+  },
+  "95956": {
+    "coordinates": {
+      "latitude": 39.8291558,
+      "longitude": -121.1366715
+    }
+  },
+  "95957": {
+    "coordinates": {
+      "latitude": 39.0676575,
+      "longitude": -121.8334868
+    }
+  },
+  "95958": {
+    "coordinates": {
+      "latitude": 39.5515199,
+      "longitude": -121.76477
+    }
+  },
+  "95959": {
+    "coordinates": {
+      "latitude": 39.3153201,
+      "longitude": -120.9417368
+    }
+  },
+  "95960": {
+    "coordinates": {
+      "latitude": 39.4259125,
+      "longitude": -121.0449768
+    }
+  },
+  "95961": {
+    "coordinates": {
+      "latitude": 39.0375178,
+      "longitude": -121.5598345
+    }
+  },
+  "95962": {
+    "coordinates": {
+      "latitude": 39.3579705,
+      "longitude": -121.2740813
+    }
+  },
+  "95963": {
+    "coordinates": {
+      "latitude": 39.7513833,
+      "longitude": -122.2200065
+    }
+  },
+  "95965": {
+    "coordinates": {
+      "latitude": 39.5137274,
+      "longitude": -121.5568104
+    }
+  },
+  "95966": {
+    "coordinates": {
+      "latitude": 39.4915751,
+      "longitude": -121.422761
+    }
+  },
+  "95967": {
+    "coordinates": {
+      "latitude": 39.75,
+      "longitude": -121.64
+    }
+  },
+  "95968": {
+    "coordinates": {
+      "latitude": 39.4159047,
+      "longitude": -121.5655424
+    }
+  },
+  "95969": {
+    "coordinates": {
+      "latitude": 39.7213638,
+      "longitude": -121.6511258
+    }
+  },
+  "95970": {
+    "coordinates": {
+      "latitude": 39.4483915,
+      "longitude": -122.026918
+    }
+  },
+  "95971": {
+    "coordinates": {
+      "latitude": 39.9402591,
+      "longitude": -120.9187827
+    }
+  },
+  "95972": {
+    "coordinates": {
+      "latitude": 39.4538587,
+      "longitude": -121.3141291
+    }
+  },
+  "95973": {
+    "coordinates": {
+      "latitude": 39.8633343,
+      "longitude": -121.856261
+    }
+  },
+  "95974": {
+    "coordinates": {
+      "latitude": 39.4915471,
+      "longitude": -121.748042
+    }
+  },
+  "95975": {
+    "coordinates": {
+      "latitude": 39.2228146,
+      "longitude": -121.1595842
+    }
+  },
+  "95976": {
+    "coordinates": {
+      "latitude": 39.7529399,
+      "longitude": -121.8678727
+    }
+  },
+  "95977": {
+    "coordinates": {
+      "latitude": 39.1571906,
+      "longitude": -121.2855249
+    }
+  },
+  "95978": {
+    "coordinates": {
+      "latitude": 39.8990778,
+      "longitude": -121.5170166
+    }
+  },
+  "95979": {
+    "coordinates": {
+      "latitude": 39.2668164,
+      "longitude": -122.5825197
+    }
+  },
+  "95980": {
+    "coordinates": {
+      "latitude": 39.93397,
+      "longitude": -121.3157
+    }
+  },
+  "95981": {
+    "coordinates": {
+      "latitude": 39.6695644,
+      "longitude": -121.0449768
+    }
+  },
+  "95982": {
+    "coordinates": {
+      "latitude": 39.1812574,
+      "longitude": -121.7993168
+    }
+  },
+  "95983": {
+    "coordinates": {
+      "latitude": 40.08226,
+      "longitude": -120.6890055
+    }
+  },
+  "95984": {
+    "coordinates": {
+      "latitude": 40.0525364,
+      "longitude": -121.1366715
+    }
+  },
+  "95986": {
+    "coordinates": {
+      "latitude": 39.3534913,
+      "longitude": -120.7551101
+    }
+  },
+  "95987": {
+    "coordinates": {
+      "latitude": 39.1274525,
+      "longitude": -122.3107517
+    }
+  },
+  "95988": {
+    "coordinates": {
+      "latitude": 39.5004505,
+      "longitude": -122.3107517
+    }
+  },
+  "95991": {
+    "coordinates": {
+      "latitude": 39.01094,
+      "longitude": -121.6169002
+    }
+  },
+  "95992": {
+    "coordinates": {
+      "latitude": 39.14,
+      "longitude": -121.62
+    }
+  },
+  "95993": {
+    "coordinates": {
+      "latitude": 39.0715086,
+      "longitude": -121.6967438
+    }
+  },
+  "96001": {
+    "coordinates": {
+      "latitude": 40.5441948,
+      "longitude": -122.4617007
+    }
+  },
+  "96002": {
+    "coordinates": {
+      "latitude": 40.5229147,
+      "longitude": -122.3221947
+    }
+  },
+  "96003": {
+    "coordinates": {
+      "latitude": 40.8002021,
+      "longitude": -122.1792927
+    }
+  },
+  "96006": {
+    "coordinates": {
+      "latitude": 41.1594371,
+      "longitude": -120.9364842
+    }
+  },
+  "96007": {
+    "coordinates": {
+      "latitude": 40.4526321,
+      "longitude": -122.28015
+    }
+  },
+  "96008": {
+    "coordinates": {
+      "latitude": 40.7159408,
+      "longitude": -122.1203009
+    }
+  },
+  "96009": {
+    "coordinates": {
+      "latitude": 41.028815,
+      "longitude": -120.9362113
+    }
+  },
+  "96010": {
+    "coordinates": {
+      "latitude": 40.9145365,
+      "longitude": -123.2377585
+    }
+  },
+  "96011": {
+    "coordinates": {
+      "latitude": 41.0762621,
+      "longitude": -122.0143947
+    }
+  },
+  "96013": {
+    "coordinates": {
+      "latitude": 41.0249681,
+      "longitude": -121.6932437
+    }
+  },
+  "96014": {
+    "coordinates": {
+      "latitude": 41.2828126,
+      "longitude": -122.7998611
+    }
+  },
+  "96015": {
+    "coordinates": {
+      "latitude": 41.4984986,
+      "longitude": -120.8700709
+    }
+  },
+  "96016": {
+    "coordinates": {
+      "latitude": 40.9403692,
+      "longitude": -121.572033
+    }
+  },
+  "96017": {
+    "coordinates": {
+      "latitude": 41.1202106,
+      "longitude": -122.2964787
+    }
+  },
+  "96019": {
+    "coordinates": {
+      "latitude": 40.69150459999999,
+      "longitude": -122.3779053
+    }
+  },
+  "96020": {
+    "coordinates": {
+      "latitude": 40.3077991,
+      "longitude": -121.2317125
+    }
+  },
+  "96021": {
+    "coordinates": {
+      "latitude": 39.8994909,
+      "longitude": -122.2200065
+    }
+  },
+  "96022": {
+    "coordinates": {
+      "latitude": 40.3346427,
+      "longitude": -122.4798416
+    }
+  },
+  "96023": {
+    "coordinates": {
+      "latitude": 41.9733773,
+      "longitude": -122.00453
+    }
+  },
+  "96024": {
+    "coordinates": {
+      "latitude": 40.5687429,
+      "longitude": -122.9129365
+    }
+  },
+  "96025": {
+    "coordinates": {
+      "latitude": 41.2032301,
+      "longitude": -122.2724791
+    }
+  },
+  "96027": {
+    "coordinates": {
+      "latitude": 41.4139431,
+      "longitude": -123.1034319
+    }
+  },
+  "96028": {
+    "coordinates": {
+      "latitude": 41.0063661,
+      "longitude": -121.4469102
+    }
+  },
+  "96029": {
+    "coordinates": {
+      "latitude": 39.9084631,
+      "longitude": -122.4580469
+    }
+  },
+  "96031": {
+    "coordinates": {
+      "latitude": 41.1634079,
+      "longitude": -123.1710196
+    }
+  },
+  "96032": {
+    "coordinates": {
+      "latitude": 41.6120868,
+      "longitude": -122.9642819
+    }
+  },
+  "96033": {
+    "coordinates": {
+      "latitude": 40.7731781,
+      "longitude": -122.5636466
+    }
+  },
+  "96034": {
+    "coordinates": {
+      "latitude": 41.4736704,
+      "longitude": -122.6191651
+    }
+  },
+  "96035": {
+    "coordinates": {
+      "latitude": 40.0358413,
+      "longitude": -122.1973081
+    }
+  },
+  "96037": {
+    "coordinates": {
+      "latitude": 41.5480069,
+      "longitude": -122.9045416
+    }
+  },
+  "96038": {
+    "coordinates": {
+      "latitude": 41.60393990000001,
+      "longitude": -122.5397599
+    }
+  },
+  "96039": {
+    "coordinates": {
+      "latitude": 41.6824048,
+      "longitude": -123.4584404
+    }
+  },
+  "96040": {
+    "coordinates": {
+      "latitude": 40.7877012,
+      "longitude": -121.4305473
+    }
+  },
+  "96041": {
+    "coordinates": {
+      "latitude": 40.56253359999999,
+      "longitude": -123.1647127
+    }
+  },
+  "96044": {
+    "coordinates": {
+      "latitude": 41.9374147,
+      "longitude": -122.4878204
+    }
+  },
+  "96046": {
+    "coordinates": {
+      "latitude": 40.5555925,
+      "longitude": -123.416721
+    }
+  },
+  "96047": {
+    "coordinates": {
+      "latitude": 40.4925482,
+      "longitude": -122.6842859
+    }
+  },
+  "96048": {
+    "coordinates": {
+      "latitude": 40.80312199999999,
+      "longitude": -123.0579066
+    }
+  },
+  "96049": {
+    "coordinates": {
+      "latitude": 41.7510424,
+      "longitude": -123.3225137
+    }
+  },
+  "96050": {
+    "coordinates": {
+      "latitude": 41.8655388,
+      "longitude": -122.8946586
+    }
+  },
+  "96051": {
+    "coordinates": {
+      "latitude": 40.9608794,
+      "longitude": -122.3844187
+    }
+  },
+  "96052": {
+    "coordinates": {
+      "latitude": 40.7679341,
+      "longitude": -122.8162341
+    }
+  },
+  "96053": {
+    "coordinates": {
+      "latitude": 40.446063,
+      "longitude": -120.664132
+    }
+  },
+  "96054": {
+    "coordinates": {
+      "latitude": 41.20818879999999,
+      "longitude": -121.1501834
+    }
+  },
+  "96055": {
+    "coordinates": {
+      "latitude": 40.0780017,
+      "longitude": -122.0610174
+    }
+  },
+  "96056": {
+    "coordinates": {
+      "latitude": 41.1376262,
+      "longitude": -121.3222078
+    }
+  },
+  "96057": {
+    "coordinates": {
+      "latitude": 41.242143,
+      "longitude": -121.9653328
+    }
+  },
+  "96058": {
+    "coordinates": {
+      "latitude": 41.7151012,
+      "longitude": -121.9097932
+    }
+  },
+  "96059": {
+    "coordinates": {
+      "latitude": 40.4350199,
+      "longitude": -121.8289745
+    }
+  },
+  "96061": {
+    "coordinates": {
+      "latitude": 40.3696189,
+      "longitude": -121.4684703
+    }
+  },
+  "96062": {
+    "coordinates": {
+      "latitude": 40.5643302,
+      "longitude": -122.0397737
+    }
+  },
+  "96063": {
+    "coordinates": {
+      "latitude": 40.3592478,
+      "longitude": -121.5940773
+    }
+  },
+  "96064": {
+    "coordinates": {
+      "latitude": 41.7368977,
+      "longitude": -122.3308804
+    }
+  },
+  "96065": {
+    "coordinates": {
+      "latitude": 40.9063814,
+      "longitude": -121.8967213
+    }
+  },
+  "96067": {
+    "coordinates": {
+      "latitude": 41.2843071,
+      "longitude": -122.375973
+    }
+  },
+  "96068": {
+    "coordinates": {
+      "latitude": 41.1055174,
+      "longitude": -121.1954797
+    }
+  },
+  "96069": {
+    "coordinates": {
+      "latitude": 40.6869239,
+      "longitude": -122.0036217
+    }
+  },
+  "96070": {
+    "coordinates": {
+      "latitude": 40.7923227,
+      "longitude": -122.3018766
+    }
+  },
+  "96071": {
+    "coordinates": {
+      "latitude": 40.664978,
+      "longitude": -121.4683317
+    }
+  },
+  "96073": {
+    "coordinates": {
+      "latitude": 40.5993942,
+      "longitude": -122.1960119
+    }
+  },
+  "96074": {
+    "coordinates": {
+      "latitude": 39.8346129,
+      "longitude": -122.6051351
+    }
+  },
+  "96075": {
+    "coordinates": {
+      "latitude": 40.3069141,
+      "longitude": -121.856261
+    }
+  },
+  "96076": {
+    "coordinates": {
+      "latitude": 40.4578164,
+      "longitude": -123.0265133
+    }
+  },
+  "96078": {
+    "coordinates": {
+      "latitude": 40.08143889999999,
+      "longitude": -122.1703241
+    }
+  },
+  "96079": {
+    "coordinates": {
+      "latitude": 40.68,
+      "longitude": -122.37
+    }
+  },
+  "96080": {
+    "coordinates": {
+      "latitude": 40.1381076,
+      "longitude": -122.4014193
+    }
+  },
+  "96084": {
+    "coordinates": {
+      "latitude": 40.9048101,
+      "longitude": -122.0229676
+    }
+  },
+  "96085": {
+    "coordinates": {
+      "latitude": 41.7687306,
+      "longitude": -122.9855839
+    }
+  },
+  "96086": {
+    "coordinates": {
+      "latitude": 41.9132748,
+      "longitude": -123.2255361
+    }
+  },
+  "96087": {
+    "coordinates": {
+      "latitude": 40.598033,
+      "longitude": -122.4904266
+    }
+  },
+  "96088": {
+    "coordinates": {
+      "latitude": 40.5328759,
+      "longitude": -121.8412133
+    }
+  },
+  "96089": {
+    "coordinates": {
+      "latitude": 40.685463,
+      "longitude": -122.4018165
+    }
+  },
+  "96090": {
+    "coordinates": {
+      "latitude": 40.0233664,
+      "longitude": -122.1220856
+    }
+  },
+  "96091": {
+    "coordinates": {
+      "latitude": 41.0629127,
+      "longitude": -122.7764116
+    }
+  },
+  "96092": {
+    "coordinates": {
+      "latitude": 39.9811574,
+      "longitude": -122.0155491
+    }
+  },
+  "96093": {
+    "coordinates": {
+      "latitude": 40.7415454,
+      "longitude": -122.9281375
+    }
+  },
+  "96094": {
+    "coordinates": {
+      "latitude": 41.4597837,
+      "longitude": -122.4329242
+    }
+  },
+  "96095": {
+    "coordinates": {
+      "latitude": 40.6338377,
+      "longitude": -122.5612525
+    }
+  },
+  "96096": {
+    "coordinates": {
+      "latitude": 40.661649,
+      "longitude": -121.8443352
+    }
+  },
+  "96097": {
+    "coordinates": {
+      "latitude": 41.7866527,
+      "longitude": -122.6592198
+    }
+  },
+  "96099": {
+    "coordinates": {
+      "latitude": 40.53,
+      "longitude": -122.71
+    }
+  },
+  "96101": {
+    "coordinates": {
+      "latitude": 41.4281801,
+      "longitude": -120.4693492
+    }
+  },
+  "96103": {
+    "coordinates": {
+      "latitude": 39.7714958,
+      "longitude": -120.6660044
+    }
+  },
+  "96104": {
+    "coordinates": {
+      "latitude": 41.4952685,
+      "longitude": -120.1082935
+    }
+  },
+  "96105": {
+    "coordinates": {
+      "latitude": 39.7819514,
+      "longitude": -120.043412
+    }
+  },
+  "96106": {
+    "coordinates": {
+      "latitude": 39.7360514,
+      "longitude": -120.5624474
+    }
+  },
+  "96107": {
+    "coordinates": {
+      "latitude": 38.566199,
+      "longitude": -119.5073543
+    }
+  },
+  "96108": {
+    "coordinates": {
+      "latitude": 41.7202877,
+      "longitude": -120.372496
+    }
+  },
+  "96109": {
+    "coordinates": {
+      "latitude": 40.0060389,
+      "longitude": -120.112735
+    }
+  },
+  "96110": {
+    "coordinates": {
+      "latitude": 41.2733534,
+      "longitude": -120.0989789
+    }
+  },
+  "96111": {
+    "coordinates": {
+      "latitude": 39.4805159,
+      "longitude": -120.043412
+    }
+  },
+  "96112": {
+    "coordinates": {
+      "latitude": 41.89364339999999,
+      "longitude": -120.1009365
+    }
+  },
+  "96113": {
+    "coordinates": {
+      "latitude": 40.1462051,
+      "longitude": -120.1170664
+    }
+  },
+  "96114": {
+    "coordinates": {
+      "latitude": 40.2847946,
+      "longitude": -120.5048792
+    }
+  },
+  "96115": {
+    "coordinates": {
+      "latitude": 41.7185114,
+      "longitude": -120.1176182
+    }
+  },
+  "96116": {
+    "coordinates": {
+      "latitude": 41.24808609999999,
+      "longitude": -120.4444501
+    }
+  },
+  "96117": {
+    "coordinates": {
+      "latitude": 40.5756358,
+      "longitude": -120.2051096
+    }
+  },
+  "96118": {
+    "coordinates": {
+      "latitude": 39.6529758,
+      "longitude": -120.2974199
+    }
+  },
+  "96119": {
+    "coordinates": {
+      "latitude": 41.0006975,
+      "longitude": -120.526055
+    }
+  },
+  "96120": {
+    "coordinates": {
+      "latitude": 38.7219006,
+      "longitude": -119.8352303
+    }
+  },
+  "96121": {
+    "coordinates": {
+      "latitude": 40.17594769999999,
+      "longitude": -120.3666099
+    }
+  },
+  "96122": {
+    "coordinates": {
+      "latitude": 39.8503956,
+      "longitude": -120.4588059
+    }
+  },
+  "96123": {
+    "coordinates": {
+      "latitude": 40.8416845,
+      "longitude": -120.2444251
+    }
+  },
+  "96124": {
+    "coordinates": {
+      "latitude": 39.6252979,
+      "longitude": -120.4588059
+    }
+  },
+  "96125": {
+    "coordinates": {
+      "latitude": 39.5719019,
+      "longitude": -120.6429991
+    }
+  },
+  "96126": {
+    "coordinates": {
+      "latitude": 39.5367728,
+      "longitude": -120.5048792
+    }
+  },
+  "96127": {
+    "coordinates": {
+      "latitude": 40.42,
+      "longitude": -120.65
+    }
+  },
+  "96128": {
+    "coordinates": {
+      "latitude": 40.3494181,
+      "longitude": -120.378138
+    }
+  },
+  "96129": {
+    "coordinates": {
+      "latitude": 39.8153434,
+      "longitude": -120.3204873
+    }
+  },
+  "96130": {
+    "coordinates": {
+      "latitude": 40.6402981,
+      "longitude": -120.6199895
+    }
+  },
+  "96132": {
+    "coordinates": {
+      "latitude": 40.8975446,
+      "longitude": -120.4345656
+    }
+  },
+  "96133": {
+    "coordinates": {
+      "latitude": 38.6588195,
+      "longitude": -119.5455699
+    }
+  },
+  "96134": {
+    "coordinates": {
+      "latitude": 41.8040105,
+      "longitude": -121.3698603
+    }
+  },
+  "96135": {
+    "coordinates": {
+      "latitude": 39.7985101,
+      "longitude": -120.1993381
+    }
+  },
+  "96136": {
+    "coordinates": {
+      "latitude": 40.3168394,
+      "longitude": -120.1358346
+    }
+  },
+  "96137": {
+    "coordinates": {
+      "latitude": 40.25757189999999,
+      "longitude": -121.1022942
+    }
+  },
+  "96140": {
+    "coordinates": {
+      "latitude": 39.2245423,
+      "longitude": -120.0954076
+    }
+  },
+  "96141": {
+    "coordinates": {
+      "latitude": 39.0782648,
+      "longitude": -120.1762494
+    }
+  },
+  "96142": {
+    "coordinates": {
+      "latitude": 39.0501303,
+      "longitude": -120.1416089
+    }
+  },
+  "96143": {
+    "coordinates": {
+      "latitude": 39.2569504,
+      "longitude": -120.0145169
+    }
+  },
+  "96145": {
+    "coordinates": {
+      "latitude": 39.1384824,
+      "longitude": -120.1647036
+    }
+  },
+  "96146": {
+    "coordinates": {
+      "latitude": 39.1630575,
+      "longitude": -120.2281933
+    }
+  },
+  "96148": {
+    "coordinates": {
+      "latitude": 39.2597037,
+      "longitude": -120.0549683
+    }
+  },
+  "96150": {
+    "coordinates": {
+      "latitude": 38.8864448,
+      "longitude": -119.9971769
+    }
+  },
+  "96151": {
+    "coordinates": {
+      "latitude": 38.93,
+      "longitude": -119.98
+    }
+  },
+  "96152": {
+    "coordinates": {
+      "latitude": 38.93,
+      "longitude": -119.98
+    }
+  },
+  "96154": {
+    "coordinates": {
+      "latitude": 38.93,
+      "longitude": -119.98
+    }
+  },
+  "96155": {
+    "coordinates": {
+      "latitude": 38.7586812,
+      "longitude": -120.078078
+    }
+  },
+  "96156": {
+    "coordinates": {
+      "latitude": 38.93,
+      "longitude": -119.98
+    }
+  },
+  "96157": {
+    "coordinates": {
+      "latitude": 38.93,
+      "longitude": -119.98
+    }
+  },
+  "96158": {
+    "coordinates": {
+      "latitude": 38.93,
+      "longitude": -119.98
+    }
+  },
+  "96160": {
+    "coordinates": {
+      "latitude": 39.33,
+      "longitude": -120.18
+    }
+  },
+  "96161": {
+    "coordinates": {
+      "latitude": 39.3021948,
+      "longitude": -120.2051096
+    }
+  },
+  "96162": {
+    "coordinates": {
+      "latitude": 39.32,
+      "longitude": -120.3
+    }
+  },
+  "96163": {
+    "coordinates": {
+      "latitude": 39.320012,
+      "longitude": -120.160271
+    }
+  },
+  "96222": {
+    "coordinates": {
+      "latitude": 40.385673,
+      "longitude": -122.279739
+    }
+  },
+  "97635": {
+    "coordinates": {
+      "latitude": 41.924974,
+      "longitude": -120.28989
+    }
+  },
+  "90090": {
+    "coordinates": {
+      "latitude": 34.0726555,
+      "longitude": -118.2441891
+    }
+  },
+  "90189": {
+    "coordinates": {
+      "latitude": 34.0599302,
+      "longitude": -118.249786
+    }
+  },
+  "90895": {
+    "coordinates": {
+      "latitude": 33.8391373,
+      "longitude": -118.2184382
+    }
+  },
+  "90899": {
+    "coordinates": {
+      "latitude": 33.77,
+      "longitude": -118.19
+    }
+  },
+  "91008": {
+    "coordinates": {
+      "latitude": 34.1624549,
+      "longitude": -117.9659037
+    }
+  },
+  "91199": {
+    "coordinates": {
+      "latitude": 34.169895,
+      "longitude": -118.1199696
+    }
+  },
+  "92010": {
+    "coordinates": {
+      "latitude": 33.159946,
+      "longitude": -117.2852467
+    }
+  },
+  "92011": {
+    "coordinates": {
+      "latitude": 33.105162,
+      "longitude": -117.2970026
+    }
+  },
+  "92081": {
+    "coordinates": {
+      "latitude": 33.1778834,
+      "longitude": -117.2534184
+    }
+  },
+  "92247": {
+    "coordinates": {
+      "latitude": 33.6786857,
+      "longitude": -116.3044138
+    }
+  },
+  "92248": {
+    "coordinates": {
+      "latitude": 33.6786171,
+      "longitude": -116.295112
+    }
+  },
+  "92331": {
+    "coordinates": {
+      "latitude": 34.06,
+      "longitude": -117.44
+    }
+  },
+  "92344": {
+    "coordinates": {
+      "latitude": 34.3811299,
+      "longitude": -117.3851496
+    }
+  },
+  "92395": {
+    "coordinates": {
+      "latitude": 34.4933111,
+      "longitude": -117.3028803
+    }
+  },
+  "92609": {
+    "coordinates": {
+      "latitude": 33.63,
+      "longitude": -117.69
+    }
+  },
+  "92617": {
+    "coordinates": {
+      "latitude": 33.6387024,
+      "longitude": -117.8370041
+    }
+  },
+  "92637": {
+    "coordinates": {
+      "latitude": 33.6108676,
+      "longitude": -117.7285406
+    }
+  },
+  "92809": {
+    "coordinates": {
+      "latitude": 33.8659034,
+      "longitude": -117.7442071
+    }
+  },
+  "93290": {
+    "coordinates": {
+      "latitude": 36.329967,
+      "longitude": -119.2899874
+    }
+  },
+  "93314": {
+    "coordinates": {
+      "latitude": 35.382088,
+      "longitude": -119.2088303
+    }
+  },
+  "93475": {
+    "coordinates": {
+      "latitude": 35.1,
+      "longitude": -120.61
+    }
+  },
+  "93619": {
+    "coordinates": {
+      "latitude": 36.911263,
+      "longitude": -119.5803605
+    }
+  },
+  "93636": {
+    "coordinates": {
+      "latitude": 36.992005,
+      "longitude": -119.8583772
+    }
+  },
+  "93723": {
+    "coordinates": {
+      "latitude": 36.7702756,
+      "longitude": -119.950926
+    }
+  },
+  "93730": {
+    "coordinates": {
+      "latitude": 36.9063167,
+      "longitude": -119.7599761
+    }
+  },
+  "93737": {
+    "coordinates": {
+      "latitude": 36.7512882,
+      "longitude": -119.6441212
+    }
+  },
+  "94158": {
+    "coordinates": {
+      "latitude": 37.7748363,
+      "longitude": -122.3872576
+    }
+  },
+  "94505": {
+    "coordinates": {
+      "latitude": 37.9011827,
+      "longitude": -121.6022434
+    }
+  },
+  "94582": {
+    "coordinates": {
+      "latitude": 37.7639471,
+      "longitude": -121.9131761
+    }
+  },
+  "94622": {
+    "coordinates": {
+      "latitude": 37.73999999999999,
+      "longitude": -122.19
+    }
+  },
+  "95391": {
+    "coordinates": {
+      "latitude": 37.7582199,
+      "longitude": -121.548418
+    }
+  },
+  "95467": {
+    "coordinates": {
+      "latitude": 38.7977373,
+      "longitude": -122.5429309
+    }
+  },
+  "95757": {
+    "coordinates": {
+      "latitude": 38.3591901,
+      "longitude": -121.422761
+    }
+  },
+  "95811": {
+    "coordinates": {
+      "latitude": 38.5967128,
+      "longitude": -121.4941738
+    }
+  }
+}

--- a/webpack/nearest.js
+++ b/webpack/nearest.js
@@ -4,8 +4,8 @@ import {
   getHasVaccine,
   getHasReport,
   getCoord,
-  fetchZipCodesData,
 } from "./data/locations.js";
+import zipCodes from "./json/zipCodes.json";
 
 import { addSitesToPage } from "./sites.js";
 import { addLocation, clearMap } from "./map.js";
@@ -16,7 +16,6 @@ let lastSearch;
 
 function loaded() {
   fetchSites();
-  fetchZipCodesData();
 
   const zipForm = document.getElementById("submit_zip_form");
   const zipInput = document.getElementById("js_zip_or_county");
@@ -225,34 +224,12 @@ async function updateSitesFromCoordinates(coordinates, repositionMap = true) {
 }
 
 async function lookup(zip) {
-  const zipCodes = await fetchZipCodesData();
-  let longitude;
-  let latitude;
-  if (zipCodes[zip]) {
-    const location = zipCodes[zip].coordinates;
-    longitude = location.lng;
-    latitude = location.lat;
-  } else {
-    const geocodeURL = `https://public.opendatasoft.com/api/records/1.0/search/?dataset=us-zip-code-latitude-and-longitude&q=${zip}`;
-    const response = await fetch(geocodeURL);
-
-    if (!response.ok) {
-      alert(window.messageCatalog["nearest_js_alert_zipcode"]);
-      return;
-    }
-
-    const results = await response.json();
-    if (results.nhits < 1) {
-      alert(window.messageCatalog["nearest_js_alert_zipcode"]);
-      return;
-    }
-
-    // Comes back in [long, lat]
-    location = results.records[0].geometry.coordinates;
-    longitude = location[0];
-    latitude = location[1];
+  const data = zipCodes[zip];
+  if (!data) {
+    alert(window.messageCatalog["nearest_js_alert_zipcode"]);
+    return;
   }
-  const coordinate = { longitude, latitude };
+  const coordinate = data.coordinates;
   return fetchFilterAndSortSites(coordinate);
 }
 


### PR DESCRIPTION
I built a new zipCodes.json file using our [existing ZIP code database][old ZIP codes] and supplementing with the [database from opendatasoft][new ZIP codes]. Where data was present in both, I preferred our existing ZIP code data (as it seems to be more accurate). I also stripped out everything except the latitude/longitude coordinates, as we aren't using any other data from the file right now.

This lets us remove the API call to opendatasoft which fired when the data wasn't in our JSON file (or when the JSON file failed to load).

Additionally, instead of fetching the ZIP code data as a separate JSON file, we embed it in the webpack bundle, which should eliminate the possibility of that fetch failing separately from the main JS fetch.

For the time being, I left the original JSON file in place, so that clients with cached JS (hopefully a dwindling breed....) can continue to pull the data.

[old ZIP codes]: https://github.com/CAVaccineInventory/gists/blob/main/zip_code_data.json
[new ZIP codes]: https://public.opendatasoft.com/explore/dataset/us-zip-code-latitude-and-longitude/

Link to Deploy Preview: https://deploy-preview-348--vaccinateca.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

Open the deploy preview and manually perform the following tests with the browser's developer console open. Fix or log any unexpected errors you see in the console. Check off the following manual tests as you go through them. Make sure to resize the screen and check for poorly positioned or spaced items at mobile and tablet sizes (60%+ of our audience is on mobile devices).

#### Homepage
- [x] Click all the links, internal and external, make sure all open the expected content.
- [x] Search box lets you search by zip or county
- [x] Counties autocomplete and take you to county page

#### /near-me
- [x] Verify searching by geolocation
- [x] Verify searching by zip code (Use one you're familiar with and double-check the listings are what you'd expect)
- [x] Map should move when you geolocate or search via zip
- [x] Run searches using different options of the filters drop down
  - [x] Ensure map populates with sites that match filter
- [x] Vaccination Site Cards show relevant information
- [x] Address in Vaccination Site Cards links to Google Maps view
- [x] Panning map changes sites listed

#### County Vaccination Site List page
- [x] List of locations displays successfully on load, split into sites with vaccine and without vaccine
- [x] Vaccination Site Cards show relevant information

#### County Policies page
- [x] Shows list of policies per county
- [x] Has search bar that autocompletes and filters content

### Vaccination Sites page
- [x] Lists all vaccination sites
- [x] Has search bar that autocomplete and filters content

#### Other pages
- [x] 'Providers' shows list of providers
- [x] 'About Us' shows prose content and FAQ
- [x] 'About Us' shows randomized list of coordinators' names

#### Did you remember to:
- [x] Check for errors in the developer console?
- [x] Resize the window to check for display/positioning issues at mobile and tablet sizes?
- [x] Check if page titles (what shows in the browser tab) are set properly?
