### PR TITLE
Remove `magin: auto` from Policy card info links

### DIFF
--- a/webpack/templates/policy.handlebars
+++ b/webpack/templates/policy.handlebars
@@ -21,22 +21,22 @@
   <div class="bg-gray-100 rounded-lg rounded-t-none">
     <div class="grid grid-cols-2 md:grid-cols-4 py-2 border-b border-gray-400 gap-1">
       {{#if infoURL}}
-      <div class="mx-auto py-2 px-6">
+      <div class="py-2 px-6">
           <a href="{{infoURL}}">{{infoLabel}}</a>
       </div>
       {{/if}}
       {{#if locationsURL}}
-      <div class="mx-auto py-2 px-6">
+      <div class="py-2 px-6">
           <a href="{{locationsURL}}">{{locationsLabel}}</a>
       </div>
       {{/if}}
       {{#if reservationURL}}
-      <div class="mx-auto py-2 px-6">
+      <div class="py-2 px-6">
           <a href="{{reservationURL}}">{{reservationLabel}}</a>
       </div>
       {{/if}}
       {{#if volunteeringURL}}
-      <div class="mx-auto py-2 px-6">
+      <div class="py-2 px-6">
           <a href="{{volunteeringURL}}">{{volunteeringLabel}}</a>
       </div>
       {{/if}}


### PR DESCRIPTION
When there is only 1 link out of 4, it looks weirdly offset. This basically left-aligns all the links and imho looks reasonable even when all 4 are present.

Link to Deploy Preview: https://deploy-preview-542--vaccinateca.netlify.app/