### PR TITLE
Fix county cards on county pages

### DIFF
--- a/_layouts/county.html
+++ b/_layouts/county.html
@@ -14,6 +14,15 @@
         <div class="md:pb-6">
           <div class="main-content px-4 md:px-8">
             <div>
+              <script id="js-county-policy-labels" type="application/json">
+                {
+                  "vaccineInfo": "{% t policy.vaccine_info %}",
+                  "vaccineLocations": "{% t policy.vaccine_locations %}",
+                  "vaccineAppointments": "{% t policy.vaccine_appointments %}",
+                  "volunteerOpportunities": "{% t policy.volunteer_opportunities %}",
+                  "latestInfo": "{% t global.latest_info %}"
+                }
+              </script>
               <ul class="js-county-policy"></ul>
               <p class="text-lg md:text-xl mt-3">{% tf county_header.html %}</p>
               <div class="text-sm">

--- a/webpack/county-page.js
+++ b/webpack/county-page.js
@@ -46,6 +46,10 @@ async function fetchCountyCard() {
     (county) => county["County"].replace(" County", "") === currentCounty()
   );
 
+  const labels = JSON.parse(
+    document.getElementById("js-county-policy-labels").textContent
+  );
+
   let notes = countyPolicy["Notes"];
   if (notes) {
     notes = sanitizeHtml(marked(notes));
@@ -54,12 +58,17 @@ async function fetchCountyCard() {
   const templateInfo = {
     name: countyPolicy["County"],
     infoURL: countyPolicy["Vaccine info URL"],
+    infoLabel: labels["vaccineInfo"],
     locationsURL: countyPolicy["Vaccine locations URL"],
+    locationsLabel: labels["vaccineLocations"],
     volunteering: countyPolicy["Official volunteering opportunities"],
+    volunteeringLabel: labels["volunteerOpportunities"],
     reservationURL: countyPolicy["countyPolicy vaccination reservations URL"],
+    reservationLabel: labels["vaccineAppointments"],
     facebook: countyPolicy["Facebook Page"],
     twitter: countyPolicy["Twitter Page"],
     notes: notes,
+    latestInfo: labels["latestInfo"],
   };
 
   document.querySelector(".js-county-policy").innerHTML = policyTemplate(


### PR DESCRIPTION
I noticed county cards on county pages has been semi-broken due to translations not working properly 😓 This PR addresses that, though not in the most ideal fashion, just in the quickest to address this.

To Deploy Preview: https://deploy-preview-550--vaccinateca.netlify.app/

---

### Manual Testing (QA)

#### County Vaccination Site List page
- [x] List of locations displays successfully on load, split into sites with vaccine and without vaccine
- [x] Vaccination Site Cards show relevant information
- [x] County policy card shows up near top of page

#### County Policies page
- [x] Shows list of policies per county
- [x] Has search bar that autocompletes and filters content
