### PR TITLE
Filter out counties without names

### DIFF
--- a/webpack/data/counties.js
+++ b/webpack/data/counties.js
@@ -9,7 +9,7 @@ async function fetchCounties() {
   }
 
   const json = await response.json();
-  return json["content"];
+  return json["content"].filter((county) => county["County"]);
 }
 
 export { fetchCounties };


### PR DESCRIPTION
Earlier today we stopped showing county info on county pages. The root cause of this was there were a few counties in the DB without a name, so later when we tried to match on them, we'd blow up. This PR fixes that.


Link to Deploy Preview: https://deploy-preview-580--vaccinateca.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

Open the deploy preview and manually perform the following tests with the browser's developer console open. Fix or log any unexpected errors you see in the console. Check off the following manual tests as you go through them. Make sure to resize the screen and check for poorly positioned or spaced items at mobile and tablet sizes (60%+ of our audience is on mobile devices).

#### County Vaccination Site List page
- [x] List of locations displays successfully on load, split into sites with vaccine and without vaccine
- [x] Vaccination Site Cards show relevant information
- [x] County policy card shows up near top of page

#### County Policies page
- [x] Shows list of policies per county
- [x] Has search bar that autocompletes and filters content

#### Did you remember to:
- [x] Check for errors in the developer console?
- [x] Resize the window to check for display/positioning issues at mobile and tablet sizes?
- [x] Check if page titles (what shows in the browser tab) are set properly?
