### PR TITLE
Add Volunteer link to nav bar

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -25,6 +25,7 @@ titles:
   providers: Providers
   nearest: Vaccination Sites Near You
   vaccinebot: VaccineBot
+  volunteer: Volunteer
 nearest:
   dropdown_1: Sites we have contacted
   dropdown_2: Sites with reported doses

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -35,7 +35,7 @@
               <a
                 href="https://vaccinateca.com/volunteer"
                 class="border border-transparent hover:border-gray-300 px-3 py-2 rounded-md text-sm font-normal text-black"
-                >Volunteer</a
+                >{% t titles.volunteer %}</a
               >
             </div>
           </div>
@@ -113,7 +113,7 @@
         <a
           href="https://vaccinateca.com/volunteer"
           class="hover:underline text-black block px-3 py-2 rounded-md text-base font-normal"
-          >Volunteer</a
+          >{% t titles.volunteer %}</a
         >
       </div>
     </div>


### PR DESCRIPTION
This PR adds a volunteering link to the top bar!

<img width="914" alt="Screen Shot 2021-03-07 at 8 04 04 🌃" src="https://user-images.githubusercontent.com/2546/110272939-51368100-7f80-11eb-87bc-0c33682441ed.png">

<img width="1126" alt="Screen Shot 2021-03-07 at 8 03 51 🌃" src="https://user-images.githubusercontent.com/2546/110272943-5398db00-7f80-11eb-99be-01587e9e1761.png">


Link to Deploy Preview: https://deploy-preview-581--vaccinateca.netlify.app/

---

### Manual Testing (QA)

#### Homepage
- [x] Click all the links, internal and external, make sure all open the expected content.
- [x] Search box lets you search by zip or county
- [x] Counties autocomplete and take you to county page

#### Did you remember to:
- [x] Check for errors in the developer console?
- [x] Resize the window to check for display/positioning issues at mobile and tablet sizes?
- [x] Check if page titles (what shows in the browser tab) are set properly?
