### PR TITLE
Fix new eligibility criteria

### DIFF
--- a/webpack/data/locations.js
+++ b/webpack/data/locations.js
@@ -161,10 +161,7 @@ function getDisplayableVaccineInfo(p) {
         p,
         "Vaccinating emergency services workers"
       ),
-      highRisk: doesLocationHaveProp(
-        p,
-        "Vaccinating high-risk individuals"
-      ),
+      highRisk: doesLocationHaveProp(p, "Vaccinating high-risk individuals"),
     };
   }
 


### PR DESCRIPTION
Turns out https://github.com/CAVaccineInventory/site/pull/582 was incorrect! New eligibility tags are being added without the leading `Yes: `, which I think makes sense, but I implemented incorrectly. Also as part of this, I found out that we have a new one for `high-risk individuals` so I added it as well.

Link to Deploy Preview: https://deploy-preview-586--vaccinateca.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

Open the deploy preview and manually perform the following tests with the browser's developer console open. Fix or log any unexpected errors you see in the console. Check off the following manual tests as you go through them. Make sure to resize the screen and check for poorly positioned or spaced items at mobile and tablet sizes (60%+ of our audience is on mobile devices).

#### Homepage
- [x] Click all the links, internal and external, make sure all open the expected content.
- [x] Search box lets you search by zip or county
- [x] Counties autocomplete and take you to county page

#### /near-me
- [x] Verify searching by geolocation
- [x] Verify searching by zip code (Use one you're familiar with and double-check the listings are what you'd expect)
- [x] Map should move when you geolocate or search via zip

#### County Vaccination Site List page
- [x] List of locations displays successfully on load, split into sites with vaccine and without vaccine
- [x] Vaccination Site Cards show relevant information
- [x] County policy card shows up near top of page

#### Did you remember to:
- [x] Check for errors in the developer console?
- [x] Resize the window to check for display/positioning issues at mobile and tablet sizes?
- [x] Check if page titles (what shows in the browser tab) are set properly?
