### PR TITLE
feat: more social, less tracking

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -11,17 +11,22 @@
     <a href="/tl/">Tagalog</a> &middot;
     <a href="/ko/">한국어</a>
   </p>
-  <a
-    href="https://twitter.com/ca_covid?ref_src=twsrc%5Etfw"
-    class="twitter-follow-button"
-    data-size="large"
-    data-dnt="true"
-    data-show-count="false"
-    >Follow @ca_covid</a
-  >
-  <script
-    async
-    src="https://platform.twitter.com/widgets.js"
-    charset="utf-8"
-  ></script>
+  <p>
+    <a
+      href="https://twitter.com/ca_covid"
+      target="_blank"
+      rel="norefferer"
+      style="display: inline-block"
+    >
+      <img class="h-8 w-8 mr-2" src="/assets/img/twitter.svg" />
+    </a>
+    <a
+      href="https://www.facebook.com/vaccinateCAcom"
+      target="_blank"
+      rel="norefferer"
+      style="display: inline-block"
+    >
+      <img class="h-8 w-8 mx-2" src="/assets/img/facebook.png" />
+    </a>
+  </p>
 </div>


### PR DESCRIPTION
Fixes #588. Adds facebook button which points to our page.

As an extra bonus, removes twitter's third party javascript (and avoids adding facebook's).

![image](https://user-images.githubusercontent.com/3347571/110900424-8f50df00-82b7-11eb-9c15-5616f4cfe5d3.png)
![image](https://user-images.githubusercontent.com/3347571/110900548-c2936e00-82b7-11eb-81e5-e08ba793d890.png)


<!--
	Replace the NNN in the URL below with the ID of this Pull Request.
	That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-589--vaccinateca.netlify.app/

---

### Manual Testing (QA)

#### Did you remember to:
- [x] Check for errors in the developer console?
- [x] Resize the window to check for display/positioning issues at mobile and tablet sizes?
- [x] Check if page titles (what shows in the browser tab) are set properly?
