### PR TITLE
feat: left-align and ltr provider notes and title

### DIFF
--- a/webpack/templates/provider.handlebars
+++ b/webpack/templates/provider.handlebars
@@ -1,7 +1,7 @@
 <li class="rounded-lg mt-4 shadow">
   <div class="p-2 flex flex-row justify-between items-center border-b border-gray-200">
     <h4 dir="ltr" class="px-2 text-xl font-bold">{{name}}</h3>
-    <span class="rounded-full bg-gray-100 px-2">{{type}}</span>
+    <span dir="ltr" class="rounded-full bg-gray-100 px-2">{{type}}</span>
   </div>
   <div class="grid grid-cols-1 md:grid-cols-3 divide-y md:divide-y-0 divide-s-0
               md:divide-s


### PR DESCRIPTION
Currently our provider info cards follow the language-default alignment and punctuation ordering.
![image](https://user-images.githubusercontent.com/3347571/111942336-528f9f80-8a90-11eb-88b7-46b6f91b19e3.png)

Force them to be `ltr` and, where appropriate, left-aligned, for un-localized fields we pull from the data feed.
![image](https://user-images.githubusercontent.com/3347571/111942988-bb2b4c00-8a91-11eb-8de8-699341eb8c68.png)


<!--
	Replace this comment with a description of the change(s) being made.
	Screenshots are especially useful if you want to show how the site is changing.
	If relevant, try to reference Issue IDs that this PR resolves.
-->

<!--
	Replace the NNN in the URL below with the ID of this Pull Request.
	That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-628--vaccinateca.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

Open the deploy preview and manually perform the following tests with the browser's developer console open. Fix or log any unexpected errors you see in the console. Check off the following manual tests as you go through them. Make sure to resize the screen and check for poorly positioned or spaced items at mobile and tablet sizes (60%+ of our audience is on mobile devices).

#### Did you remember to:
- [x] Check for errors in the developer console?
- [x] Resize the window to check for display/positioning issues at mobile and tablet sizes?
- [x] Check if page titles (what shows in the browser tab) are set properly?
