### PR TITLE
feat: set coordinators list ltr

### DIFF
--- a/about-us.md
+++ b/about-us.md
@@ -69,7 +69,7 @@ order: 5
 <h3 class="text-lg font-bold mt-6 mb-2 bg-yellow-300 px-0.5 py-1">
   {% t about_us.coordinators %}
 </h3>
-<span id="js-people-list">
+<span dir="ltr" id="js-people-list" class="text-left">
 {% for coordinator in site.data.coordinators %} <a href="{{ coordinator[1] }}">{{ coordinator[0] }}</a> {% endfor %}
 </span>.
 


### PR DESCRIPTION
These are - and always will be - non-localized English names, so force the formatting to be `ltr` and `text-left`.

Link to Deploy Preview: https://deploy-preview-645--vaccinateca.netlify.app/

---

### Manual Testing (QA)

#### Other pages
- [ ] 'Providers' shows list of providers
- [ ] 'About Us' shows prose content and FAQ
- [ ] 'About Us' shows randomized list of coordinators' names

#### Did you remember to:
- [ ] Check for errors in the developer console?
- [ ] Resize the window to check for display/positioning issues at mobile and tablet sizes?
- [ ] Check if page titles (what shows in the browser tab) are set properly?
