### PR TITLE
use locale for relative timestamp in vaccinespotter string

### DIFF
--- a/webpack/data/locations.js
+++ b/webpack/data/locations.js
@@ -247,9 +247,7 @@ function getDisplayableVaccineInfo(p) {
       return null;
     }
 
-    return DateTime.fromISO(
-      p["vaccineSpotterStatus"]["lastCheckedAt"]
-    ).toRelative();
+    return getTimeDiffFromNow(p["vaccineSpotterStatus"]["lastCheckedAt"]);
   }
 
   function getVaccineSpotterURL(p) {


### PR DESCRIPTION
Pretty simple change - just make sure we use locale when generating the relative date for the vaccine spotter strings. We already had a helper function for that, so just reused.

Link to Deploy Preview: https://deploy-preview-646--vaccinateca.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

Open the deploy preview and manually perform the following tests with the browser's developer console open. Fix or log any unexpected errors you see in the console. Check off the following manual tests as you go through them. Make sure to resize the screen and check for poorly positioned or spaced items at mobile and tablet sizes (60%+ of our audience is on mobile devices).

#### Homepage
- [x] Click all the links, internal and external, make sure all open the expected content.
- [x] Search box lets you search by zip or county
- [x] Counties autocomplete and take you to county page

#### /near-me
- [x] Verify searching by geolocation
- [x] Verify searching by zip code (Use one you're familiar with and double-check the listings are what you'd expect)
- [x] Map should move when you geolocate or search via zip
- [x] Run searches using different options of the filters drop down
  - [x] Ensure map populates with sites that match filter
- [x] Vaccination Site Cards show relevant information
- [x] Address in Vaccination Site Cards links to Google Maps view
- [x] Panning map changes sites listed

#### County Vaccination Site List page
- [x] List of locations displays successfully on load, split into sites with vaccine and without vaccine
- [x] Vaccination Site Cards show relevant information
- [x] County policy card shows up near top of page

#### County Policies page
- [x] Shows list of policies per county
- [x] Has search bar that autocompletes and filters content

#### Other pages
- [x] 'Providers' shows list of providers
- [x] 'About Us' shows prose content and FAQ
- [x] 'About Us' shows randomized list of coordinators' names

#### Did you remember to:
- [x] Check for errors in the developer console?
- [x] Resize the window to check for display/positioning issues at mobile and tablet sizes?
- [x] Check if page titles (what shows in the browser tab) are set properly?
