### PR TITLE
Add default filters to catch more sites

### DIFF
--- a/webpack/nearest.js
+++ b/webpack/nearest.js
@@ -204,7 +204,14 @@ async function updateSitesOnMap() {
       return getHasVaccine(site);
     });
 
-    const filters = [];
+    // Include yeses we don't filter on
+    const filters = [
+      "Yes: appointment calendar currently full",
+      "Yes: appointment required",
+      "Yes: restricted to county residents",
+      "Yes: restricted to city residents",
+      "Yes: must be a current patient",
+    ];
 
     const ageFilter = document.getElementById("js-age-filter");
     if (ageFilter) {


### PR DESCRIPTION
When looking at the site earlier with @rhkeeler, we noticed we couldn't find the Moscone super site, which is 😱. I figured out that it's *only* tagged with `Yes: appointment calendar currently full`. While I think that we probably can put more tags on it, we should *also* not be filtering out a site that has such a small set of tags. This PR adds some defaults to the filtering that we don't have options around, so that sites only tagged with those, and nothing else, will always show up.

Link to Deploy Preview: https://deploy-preview-654--vaccinateca.netlify.app/

---

### Manual Testing (QA)


#### /near-me
- [x] Verify searching by geolocation
- [x] Verify searching by zip code (Use one you're familiar with and double-check the listings are what you'd expect)
- [x] Map should move when you geolocate or search via zip
- [x] Run searches using different options of the filters drop down
  - [x] Ensure map populates with sites that match filter
- [x] Vaccination Site Cards show relevant information
- [x] Address in Vaccination Site Cards links to Google Maps view
- [x] Panning map changes sites listed

#### Did you remember to:
- [x] Check for errors in the developer console?
- [x] Resize the window to check for display/positioning issues at mobile and tablet sizes?
- [x] Check if page titles (what shows in the browser tab) are set properly?
