### PR TITLE
add eligibility determined by <source> website to basefilters

### DIFF
--- a/webpack/data/locations.js
+++ b/webpack/data/locations.js
@@ -348,6 +348,9 @@ function filterSitesByAvailability(sites, filters) {
     "Yes: restricted to county residents",
     "Yes: restricted to city residents",
     "Yes: must be a current patient",
+    "Eligibility determined by state website",
+    "Eligibility determined by county website",
+    "Eligibility determined by provider website",
   ];
 
   return sites.filter((site) => {


### PR DESCRIPTION
See associated PR for scooby here: https://github.com/CAVaccineInventory/help.vaccinate/pull/115

Add new baseFilters as we are adding a change to scooby to allow users to state that eligibility is determined by state/county/provider websites. In a future PR, I will make it so if eligibility is indeed determined by the county, we display the county info inline with the site card. 


Link to Deploy Preview: https://deploy-preview-657--vaccinateca.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

Open the deploy preview and manually perform the following tests with the browser's developer console open. Fix or log any unexpected errors you see in the console. Check off the following manual tests as you go through them. Make sure to resize the screen and check for poorly positioned or spaced items at mobile and tablet sizes (60%+ of our audience is on mobile devices).

#### Homepage
- [x] Click all the links, internal and external, make sure all open the expected content.
- [x] Search box lets you search by zip or county
- [x] Counties autocomplete and take you to county page

#### /near-me
- [x] Verify searching by geolocation
- [x] Verify searching by zip code (Use one you're familiar with and double-check the listings are what you'd expect)
- [x] Map should move when you geolocate or search via zip
- [x] Run searches using different options of the filters drop down
  - [x] Ensure map populates with sites that match filter
- [x] Vaccination Site Cards show relevant information
- [x] Address in Vaccination Site Cards links to Google Maps view
- [x] Panning map changes sites listed

#### County Vaccination Site List page
- [x] List of locations displays successfully on load, split into sites with vaccine and without vaccine
- [x] Vaccination Site Cards show relevant information
- [x] County policy card shows up near top of page

#### County Policies page
- [x] Shows list of policies per county
- [x] Has search bar that autocompletes and filters content

#### Other pages
- [x] 'Providers' shows list of providers
- [x] 'About Us' shows prose content and FAQ
- [x] 'About Us' shows randomized list of coordinators' names

#### Did you remember to:
- [x] Check for errors in the developer console?
- [x] Resize the window to check for display/positioning issues at mobile and tablet sizes?
- [x] Check if page titles (what shows in the browser tab) are set properly?
