### PR TITLE
Stop double loading locations on Nearby view

### DIFF
--- a/webpack/mapLoader.js
+++ b/webpack/mapLoader.js
@@ -1,6 +1,3 @@
-import { getHasVaccine, fetchSites } from "./data/locations.js";
-import { addLocation } from "./map.js";
-
 window.addEventListener("load", initMap);
 
 window.map = {};


### PR DESCRIPTION
It was pointed out that the nearby page is a bit slow. Now, a big reason for this is filtering code. However, when looking into it, it became clear we were double loading locations onto the map. Initially we'd load the map and add all the locations, then we'd apply filtering, clear all the locations, and re-add only those needed.

This PR removes that initial location load. It's not a silver bullet for the performance, but it certainly helps.

Link to Deploy Preview: https://deploy-preview-665--vaccinateca.netlify.app/

---

### Manual Testing (QA)

#### /near-me
- [x] Verify searching by geolocation
- [x] Verify searching by zip code (Use one you're familiar with and double-check the listings are what you'd expect)
- [x] Map should move when you geolocate or search via zip
- [x] Run searches using different options of the filters drop down
  - [x] Ensure map populates with sites that match filter
- [x] Vaccination Site Cards show relevant information
- [x] Address in Vaccination Site Cards links to Google Maps view
- [x] Panning map changes sites listed

#### Did you remember to:
- [x] Check for errors in the developer console?
- [x] Resize the window to check for display/positioning issues at mobile and tablet sizes?
- [x] Check if page titles (what shows in the browser tab) are set properly?
