### PR TITLE
fix typo in plaintext county copy string

### DIFF
--- a/webpack/sites.js
+++ b/webpack/sites.js
@@ -153,7 +153,7 @@ function generateRestrictions(info, plainText = false) {
     const link = plainText
       ? `${t(
         "site_template.eligibility_by_county"
-      )} (https://vaccinateca.com/${urlPath})`
+      )} (https://vaccinateca.com${urlPath})`
       : `<a target="_blank" href=${urlPath}>${t(
         "site_template.eligibility_by_county"
       )}</a>`;


### PR DESCRIPTION
Silly mistake by me, the plain text was adding an unnecessary `/` character to the county URL. Not a big deal because the link still works, but it looks sloppy :). This fixes that.

<!--
	Replace the NNN in the URL below with the ID of this Pull Request.
	That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-670--vaccinateca.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

Open the deploy preview and manually perform the following tests with the browser's developer console open. Fix or log any unexpected errors you see in the console. Check off the following manual tests as you go through them. Make sure to resize the screen and check for poorly positioned or spaced items at mobile and tablet sizes (60%+ of our audience is on mobile devices).


#### /near-me
- [ ] Verify searching by geolocation
- [ ] Verify searching by zip code (Use one you're familiar with and double-check the listings are what you'd expect)
- [ ] Map should move when you geolocate or search via zip
- [ ] Run searches using different options of the filters drop down
  - [ ] Ensure map populates with sites that match filter
- [ ] Vaccination Site Cards show relevant information
- [ ] Address in Vaccination Site Cards links to Google Maps view
- [ ] Panning map changes sites listed

#### Did you remember to:
- [ ] Check for errors in the developer console?
- [ ] Resize the window to check for display/positioning issues at mobile and tablet sizes?
- [ ] Check if page titles (what shows in the browser tab) are set properly?
