### PR TITLE
Update eligibility from age 65+ to age 50+

### DIFF
--- a/_i18n/en.yml
+++ b/_i18n/en.yml
@@ -129,8 +129,8 @@ index:
     We are a group of volunteers calling hospitals and pharmacies daily to track their vaccine availability and their processes for getting one.
   disclaimer_1: |
     The State of California has
-    <a href="https://www.npr.org/2021/01/13/956574947/california-to-vaccinate-residents-65-or-older-against-covid-19">approved</a>
-    giving the COVID-19 vaccine to people age 65 and older. California’s statewide
+    <a href="https://www.gov.ca.gov/2021/03/25/state-expands-vaccine-eligibility-to-50-californians-starting-april-1-and-all-individuals-16-on-april-15-based-on-expected-supply-increases/">approved</a>
+    giving the COVID-19 vaccine to people age 50 and older. California’s statewide
     COVID-19 vaccination program has been evolving rapidly.
     <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/index.html">Federal</a>,
     <a href="https://covid19.ca.gov/vaccines/">state</a>,


### PR DESCRIPTION
The home page currently states: "The State of California has approved giving the COVID-19 vaccine to people age 65 and older."

This pull request updates it to state: "The State of California has approved giving the COVID-19 vaccine to people age 50 and older."

The home page currently links the word "approved" to: https://www.npr.org/2021/01/13/956574947/california-to-vaccinate-residents-65-or-older-against-covid-19

This pull request updates the link to: https://www.gov.ca.gov/2021/03/25/state-expands-vaccine-eligibility-to-50-californians-starting-april-1-and-all-individuals-16-on-april-15-based-on-expected-supply-increases/


<!--
	Replace the NNN in the URL below with the ID of this Pull Request.
	That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-672--vaccinateca.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

This PR is solely a minor content adjustment.