### PR TITLE
delete unused filter function to fix main's lint issue

### DIFF
--- a/webpack/data/locations.js
+++ b/webpack/data/locations.js
@@ -354,34 +354,6 @@ function sortByRecency(sites) {
   });
 }
 
-function filterSitesByAvailability(sites, filters) {
-  if (filters.length === 0) {
-    return sites;
-  }
-
-  const baseFilters = [
-    "Yes: appointment calendar currently full",
-    "Yes: appointment required",
-    "Yes: restricted to county residents",
-    "Yes: restricted to city residents",
-    "Yes: must be a current patient",
-    "Eligibility determined by state website",
-    "Eligibility determined by county website",
-    "Eligibility determined by provider website",
-  ];
-
-  return sites.filter((site) => {
-    // If the only tags a site has are those in these unfiltered tags, lets
-    // always show it
-    if (
-      site["Availability Info"].every((value) => baseFilters.includes(value))
-    ) {
-      return true;
-    }
-    return site["Availability Info"].some((value) => filters.includes(value));
-  });
-}
-
 export {
   fetchSites,
   getHasVaccine,
@@ -392,5 +364,4 @@ export {
   getTimeDiffFromNow,
   splitSitesByVaccineState,
   sortByRecency,
-  filterSitesByAvailability,
 };

--- a/webpack/nearest.js
+++ b/webpack/nearest.js
@@ -5,7 +5,6 @@ import {
   getHasReport,
   sortByRecency,
   splitSitesByVaccineState,
-  filterSitesByAvailability,
   getCoord,
 } from "./data/locations.js";
 import zipCodes from "./json/zipCodes.json";


### PR DESCRIPTION
Builds are failing due to a lint issue on main - this PR addresses that by deleting the unused import + deleting the now unused function.
<!--
	Replace the NNN in the URL below with the ID of this Pull Request.
	That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-676--vaccinateca.netlify.app/

---
