### PR TITLE
remove unused seo gem + related config variables

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,11 +29,6 @@ end
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 
-# For settings social media meta-data so that links look good
-# github pages support 2.6.1 and not more recent versions
-# source: https://pages.github.com/versions/
-gem 'jekyll-seo-tag', '2.6.1'
-
 gem "json", "~> 2.5"
 
 gem "bigdecimal", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,6 @@ DEPENDENCIES
   jekyll (~> 4.1.1)
   jekyll-feed (~> 0.12)
   jekyll-multiple-languages-plugin
-  jekyll-seo-tag (= 2.6.1)
   json (~> 2.5)
   minima (~> 2.5)
   tzinfo (~> 1.2)

--- a/_config.yml
+++ b/_config.yml
@@ -34,26 +34,6 @@ google_analytics_id: G-C1C9341MGL
 plugins:
   - jekyll-multiple-languages-plugin
 
-## Social media stuff supported by jekyll-seo-tag
-tagline: COVID-19 Vaccine Availability in California
-twitter:
-  card: summary_large_image
-  username: ca_covid
-
-social:
-  links:
-    - https://twitter.com/ca_covid
-    - https://github.com/CAVaccineInventory
-
-
-# Image used by jekyll-seo-tag plugin in the JSON-LD tag.
-logo: "/assets/img/logo.png"
-defaults:
-  - scope:
-      path: ""
-    values:
-      # Image used by jekyll-seo-tag plugin to generate Open Graph and other related meta tags.
-      image: /assets/img/link_card_image.png
 
 collections:
   counties:


### PR DESCRIPTION
While working on VaccinateTheStates, i ported over the SEO logic from here. I realized that we had custom SEO in the <head> tag as well as this seo jekyll gem. Turns out we aren't even using the jekyll gem. Inspecting our head tag shows the SEO tags we add to our custom head includes, and further we never even add the `{% seo %}` logic to inject it on our pages.

This PR cleans up the unused gem. That way the next person who touches SEO isn't very confused like i was 😄 
<!--
	Replace the NNN in the URL below with the ID of this Pull Request.
	That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-708--vaccinateca.netlify.app/

---

### Manual Testing (QA)

- [x] Open page and inspect the output head HTML. Notice it is unchanged 