### PR TITLE
Remove the county links from the site's homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,51 +29,6 @@ homepage: true
     </div>
   </div>
 
-  <div
-    class="mt-16 bg-yellow-300 py-8 md:py-12 w-screen lg:flex lg:justify-center"
-  >
-    <div
-      class="flex flex-col-reverse px-4 md:space-y-0 md:grid md:grid-cols-2 md:gap-x-10 md:px-12 lg:container"
-    >
-      <div>
-        <div class="text-xl font-bold mb-4 md:mb-8">
-          {% t index.locations_by_county %}
-        </div>
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-x-4 gap-y-4">
-          {% for county in site.data.front_page_counties %}
-          <a
-            class="text-black bg-white py-3 px-4 rounded-md shadow-md {% if forloop.index > 4 %}hidden md:block{% endif %}"
-            href="{% if site.lang != 'en' %}/{{ site.lang }}{% endif %}/counties/{{ county[1] }}"
-          >
-            {{ county[0] }}
-          </a>
-          {% endfor %}
-          <a
-            id="js-find-your-county"
-            class="text-white bg-gray-800 py-3 px-4 rounded-md shadow-md"
-            href="#js-zip-or-county"
-            >{% t index.find_county %}</a
-          >
-        </div>
-      </div>
-      <div class="pb-6 md:pb-0">
-        <div class="text-xl font-bold mb-4 md:mb-8">
-          {% t index.more_info %}
-        </div>
-        <div>
-          <p>
-            {% t index.disclaimer_1 %}
-          </p>
-          <p>
-            {% t index.disclaimer_2 %}
-          </p>
-          <a class="text-black" href="{% link about-us.md %}">
-            {% t index.about_us %} &rarr;
-          </a>
-        </div>
-      </div>
-    </div>
-  </div>
 
   <div class="mt-16 flex flex-col items-center text-center">
     <p>{% t index.corrections %}</p>


### PR DESCRIPTION
This change removes the "county links" section from the VCA homepage.

<!--
	Replace the NNN in the URL below with the ID of this Pull Request.
	That's the URL where Netlify will automatically deploy a staging build.
-->
Link to Deploy Preview: https://deploy-preview-925--vaccinateca.netlify.app/

---

### Manual Testing (QA)

_(Note: Use your best judgement for time management. If this PR is a minor content adjustment, you might not invest in the full list of QA checks below. But for medium-large PRs, we recommend a thorough review.)_

Open the deploy preview and manually perform the following tests with the browser's developer console open. Fix or log any unexpected errors you see in the console. Check off the following manual tests as you go through them. Make sure to resize the screen and check for poorly positioned or spaced items at mobile and tablet sizes (60%+ of our audience is on mobile devices).

#### Homepage
- [ ] Click all the links, internal and external, make sure all open the expected content.
- [ ] Search box lets you search by zip or county
- [ ] Counties autocomplete and take you to county page

#### /near-me
- [ ] Verify searching by geolocation
- [ ] Verify searching by zip code (Use one you're familiar with and double-check the listings are what you'd expect)
- [ ] Map should move when you geolocate or search via zip
- [ ] Run searches using different options of the filters drop down
  - [ ] Ensure map populates with sites that match filter
- [ ] Vaccination Site Cards show relevant information
- [ ] Address in Vaccination Site Cards links to Google Maps view
- [ ] Panning map changes sites listed

#### County Vaccination Site List page
- [ ] List of locations displays successfully on load, split into sites with vaccine and without vaccine
- [ ] Vaccination Site Cards show relevant information
- [ ] County policy card shows up near top of page

#### County Policies page
- [ ] Shows list of policies per county
- [ ] Has search bar that autocompletes and filters content

#### Other pages
- [ ] 'About Us' shows prose content and FAQ
- [ ] 'About Us' shows randomized list of coordinators' names

#### Did you remember to:
- [ ] Check for errors in the developer console?
- [ ] Resize the window to check for display/positioning issues at mobile and tablet sizes?
- [ ] Check if page titles (what shows in the browser tab) are set properly?
